### PR TITLE
データ保存先ディレクトリを.storage配下に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ composer require simplebbs/simple-bbs
 
 ## セットアップ
 1. Web ルートを `vendor/simplebbs/simple-bbs/public` に向けるか、`public/` ディレクトリの内容を任意の公開ディレクトリに配置します。
-2. `storage/` ディレクトリを BBS のデータ格納用に書き込み可能へ設定するか、環境変数 `SIMPLEBBS_STORAGE_PATH` で任意の書き込み先パスを指定します。
+2. `.storage/` ディレクトリを BBS のデータ格納用に書き込み可能へ設定するか、環境変数 `SIMPLEBBS_STORAGE_PATH` で任意の書き込み先パスを指定します。
 3. ブラウザでアクセスすると、ボード作成からスレッド・投稿まで利用できます。
 
 `public/index.php` では `SimpleBBS\\Application` を生成し、HTTP リクエストを処理します。設置先で Twig のカスタマイズを行いたい場合は、

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,14 +18,14 @@ public/
   index.php             ... フロントコントローラ
   css/, js/             ... アセット
 resources/views/        ... Twig テンプレート
-storage/                ... SQLite ファイル配置 (system.sqlite と boards/*.sqlite を生成)
+.storage/               ... SQLite ファイル配置 (system.sqlite と boards/*.sqlite を生成)
 docs/                   ... ドキュメント
 ```
 
 ## データベース
-- **システムDB (`storage/system.sqlite`)**
+- **システムDB (`.storage/system.sqlite`)**
   - `boards` テーブル: ボードのメタ情報(スラッグ、タイトル、説明、作成日時) を保持。
-- **ボードDB (`storage/boards/{slug}.sqlite`)**
+- **ボードDB (`.storage/boards/{slug}.sqlite`)**
   - `threads` テーブル: スレッドタイトルと作成・更新日時。
   - `posts` テーブル: スレッド内の投稿(投稿者、本文、投稿日時)。
 
@@ -61,7 +61,7 @@ docs/                   ... ドキュメント
 
 ## 組み込み手順概要
 1. `composer require simplebbs/simple-bbs` でパッケージを導入。(開発中はローカルパス指定も可能)
-2. `public/index.php` を Web ルートに配置し、`storage/` ディレクトリへの書き込み権限を付与するか、環境変数 `SIMPLEBBS_STORAGE_PATH`
+2. `public/index.php` を Web ルートに配置し、`.storage/` ディレクトリへの書き込み権限を付与するか、環境変数 `SIMPLEBBS_STORAGE_PATH`
    で別のディレクトリを指定します。
 3. 必要に応じて Twig テンプレートや CSS をカスタマイズしてサイトデザインと統一。
 

--- a/public/index.php
+++ b/public/index.php
@@ -5,7 +5,7 @@ use SimpleBBS\Http\Request;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$storagePath = getenv('SIMPLEBBS_STORAGE_PATH') ?: __DIR__ . '/../storage';
+$storagePath = getenv('SIMPLEBBS_STORAGE_PATH') ?: __DIR__ . '/../.storage';
 
 $app = Application::create($storagePath);
 $app->handle(Request::fromGlobals());

--- a/src/Application.php
+++ b/src/Application.php
@@ -37,7 +37,7 @@ class Application
         ?string $viewsPath = null
     ): self {
         $packageRoot = dirname(__DIR__);
-        $storagePath ??= $packageRoot . '/storage';
+        $storagePath ??= $packageRoot . '/.storage';
         $viewsPath ??= $packageRoot . '/resources/views';
 
         return new self($storagePath, $view, $viewsPath);


### PR DESCRIPTION
## 概要
- アプリケーションとエントリポイントのデフォルト保存先を.storageに変更
- ドキュメントを新しいディレクトリ構成に合わせて更新

## テスト
- 未実施（ドキュメントと設定変更のみ）

------
https://chatgpt.com/codex/tasks/task_e_68dcd01c766083308da38a0ada86db22