### PR TITLE
BBS機能をファサードクラス化して外部利用を容易にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ composer require simplebbs/simple-bbs
 `public/index.php` では `SimpleBBS\\Application` を生成し、HTTP リクエストを処理します。設置先で Twig のカスタマイズを行いたい場合は、
 `SimpleBBS\\Application::create()` の第 2 引数以降に Twig Environment やビューのパスを渡してください。
 
+## 他システムからの利用
+
+`SimpleBBS\\SimpleBBS` を生成することで、ボードやスレッド操作用のファサードクラスに直接アクセスできます。
+
+```php
+use SimpleBBS\SimpleBBS;
+
+$bbs = SimpleBBS::create('/path/to/storage');
+
+// ボード一覧を取得
+$boards = $bbs->boards()->listBoards();
+
+// スレッドの作成
+$threadId = $bbs->threads()->createThread('general', 'はじめまして', '管理人', 'よろしくお願いします。');
+
+// ストレージに関する情報へアクセス
+$storagePath = $bbs->system()->storagePath();
+```
+
+`SimpleBBS\\Application::create()` に `SimpleBBS` インスタンスを渡すことで、Web アプリケーションと他システムで同じコンポーネン
+ト構成を共有することも可能です。
+
 ## 必要条件
 - PHP 8.1 以上
 - SQLite3 拡張

--- a/public/index.php
+++ b/public/index.php
@@ -2,10 +2,12 @@
 
 use SimpleBBS\Application;
 use SimpleBBS\Http\Request;
+use SimpleBBS\SimpleBBS;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
 $storagePath = getenv('SIMPLEBBS_STORAGE_PATH') ?: __DIR__ . '/../.storage';
 
-$app = Application::create($storagePath);
+$bbs = SimpleBBS::create($storagePath);
+$app = Application::create(storagePath: $storagePath, bbs: $bbs);
 $app->handle(Request::fromGlobals());

--- a/src/Boards/BoardManager.php
+++ b/src/Boards/BoardManager.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace SimpleBBS\Boards;
+
+use SimpleBBS\Services\BoardService;
+
+/**
+ * ボードに関するユースケースを取り扱うファサードクラス。
+ *
+ * コントローラや他システムから直接呼び出しやすいように、
+ * BoardService の公開メソッドを委譲しています。
+ */
+class BoardManager
+{
+    public function __construct(private readonly BoardService $service)
+    {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function listBoards(): array
+    {
+        return $this->service->listBoards();
+    }
+
+    public function getBoard(string $slug): array
+    {
+        return $this->service->getBoard($slug);
+    }
+
+    public function createBoard(string $title, ?string $slug, ?string $description): array
+    {
+        return $this->service->createBoard($title, $slug, $description);
+    }
+
+    public function service(): BoardService
+    {
+        return $this->service;
+    }
+}

--- a/src/Controllers/BoardController.php
+++ b/src/Controllers/BoardController.php
@@ -2,9 +2,9 @@
 
 namespace SimpleBBS\Controllers;
 
+use SimpleBBS\Boards\BoardManager;
 use SimpleBBS\Http\Request;
-use SimpleBBS\Services\BoardService;
-use SimpleBBS\Services\ThreadService;
+use SimpleBBS\Threads\ThreadManager;
 use InvalidArgumentException;
 use Twig\Environment;
 
@@ -12,14 +12,14 @@ class BoardController
 {
     public function __construct(
         private readonly Environment $view,
-        private readonly BoardService $boardService,
-        private readonly ThreadService $threadService
+        private readonly BoardManager $boardManager,
+        private readonly ThreadManager $threadManager
     ) {
     }
 
     public function index(Request $request): string
     {
-        $boards = $this->boardService->listBoards();
+        $boards = $this->boardManager->listBoards();
 
         return $this->view->render('boards/index.twig', [
             'boards' => $boards,
@@ -30,7 +30,7 @@ class BoardController
     public function store(Request $request): void
     {
         try {
-            $board = $this->boardService->createBoard(
+            $board = $this->boardManager->createBoard(
                 (string)$request->input('title'),
                 $request->input('slug'),
                 $request->input('description')
@@ -39,7 +39,7 @@ class BoardController
             header('Location: ?route=boards.show&slug=' . urlencode($board['slug']));
             exit;
         } catch (InvalidArgumentException $exception) {
-            $boards = $this->boardService->listBoards();
+            $boards = $this->boardManager->listBoards();
             echo $this->view->render('boards/index.twig', [
                 'boards' => $boards,
                 'errors' => [$exception->getMessage()],
@@ -55,8 +55,8 @@ class BoardController
     public function show(Request $request): string
     {
         $slug = (string)$request->query('slug');
-        $board = $this->boardService->getBoard($slug);
-        $threads = $this->threadService->listThreads($board['slug']);
+        $board = $this->boardManager->getBoard($slug);
+        $threads = $this->threadManager->listThreads($board['slug']);
 
         return $this->view->render('boards/show.twig', [
             'board' => $board,

--- a/src/Controllers/ThreadController.php
+++ b/src/Controllers/ThreadController.php
@@ -2,9 +2,9 @@
 
 namespace SimpleBBS\Controllers;
 
+use SimpleBBS\Boards\BoardManager;
 use SimpleBBS\Http\Request;
-use SimpleBBS\Services\BoardService;
-use SimpleBBS\Services\ThreadService;
+use SimpleBBS\Threads\ThreadManager;
 use InvalidArgumentException;
 use Twig\Environment;
 
@@ -12,18 +12,18 @@ class ThreadController
 {
     public function __construct(
         private readonly Environment $view,
-        private readonly BoardService $boardService,
-        private readonly ThreadService $threadService
+        private readonly BoardManager $boardManager,
+        private readonly ThreadManager $threadManager
     ) {
     }
 
     public function create(Request $request): void
     {
         $slug = (string)$request->query('slug');
-        $board = $this->boardService->getBoard($slug);
+        $board = $this->boardManager->getBoard($slug);
 
         try {
-            $threadId = $this->threadService->createThread(
+            $threadId = $this->threadManager->createThread(
                 $board['slug'],
                 (string)$request->input('title'),
                 (string)$request->input('author_name'),
@@ -33,7 +33,7 @@ class ThreadController
             header('Location: ?route=threads.show&slug=' . urlencode($board['slug']) . '&thread=' . $threadId);
             exit;
         } catch (InvalidArgumentException $exception) {
-            $threads = $this->threadService->listThreads($board['slug']);
+            $threads = $this->threadManager->listThreads($board['slug']);
             echo $this->view->render('boards/show.twig', [
                 'board' => $board,
                 'threads' => $threads,
@@ -54,8 +54,8 @@ class ThreadController
         $slug = (string)$request->query('slug');
         $threadId = (int)$request->query('thread');
 
-        $board = $this->boardService->getBoard($slug);
-        $thread = $this->threadService->getThread($board['slug'], $threadId);
+        $board = $this->boardManager->getBoard($slug);
+        $thread = $this->threadManager->getThread($board['slug'], $threadId);
 
         return $this->view->render('threads/show.twig', [
             'board' => $board,
@@ -68,10 +68,10 @@ class ThreadController
     {
         $slug = (string)$request->query('slug');
         $threadId = (int)$request->query('thread');
-        $board = $this->boardService->getBoard($slug);
+        $board = $this->boardManager->getBoard($slug);
 
         try {
-            $this->threadService->addPost(
+            $this->threadManager->addPost(
                 $board['slug'],
                 $threadId,
                 (string)$request->input('author_name'),
@@ -81,7 +81,7 @@ class ThreadController
             header('Location: ?route=threads.show&slug=' . urlencode($board['slug']) . '&thread=' . $threadId);
             exit;
         } catch (InvalidArgumentException $exception) {
-            $thread = $this->threadService->getThread($board['slug'], $threadId);
+            $thread = $this->threadManager->getThread($board['slug'], $threadId);
             echo $this->view->render('threads/show.twig', [
                 'board' => $board,
                 'thread' => $thread,

--- a/src/Management/SystemManager.php
+++ b/src/Management/SystemManager.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SimpleBBS\Management;
+
+use SimpleBBS\Support\DatabaseManager;
+
+/**
+ * ストレージやデータベースなど、システム全体の管理機能を提供します。
+ */
+class SystemManager
+{
+    public function __construct(private readonly DatabaseManager $databaseManager)
+    {
+    }
+
+    public function storagePath(): string
+    {
+        return $this->databaseManager->getDataPath();
+    }
+
+    public function boardDatabasePath(string $slug): string
+    {
+        return $this->databaseManager->getBoardDatabasePath($slug);
+    }
+
+    public function ensureBoardStorage(string $slug): void
+    {
+        $this->databaseManager->ensureBoardDatabase($slug);
+    }
+
+    public function databaseManager(): DatabaseManager
+    {
+        return $this->databaseManager;
+    }
+}

--- a/src/SimpleBBS.php
+++ b/src/SimpleBBS.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace SimpleBBS;
+
+use SimpleBBS\Boards\BoardManager;
+use SimpleBBS\Management\SystemManager;
+use SimpleBBS\Repositories\BoardRepository;
+use SimpleBBS\Repositories\ThreadRepository;
+use SimpleBBS\Services\BoardService;
+use SimpleBBS\Services\ThreadService;
+use SimpleBBS\Support\DatabaseManager;
+use SimpleBBS\Threads\ThreadManager;
+
+/**
+ * SimpleBBS のコンポーネントをまとめて提供するエントリポイント。
+ *
+ * public/index.php からの単体利用だけでなく、他システムへの
+ * 組み込み時にも本クラスを new / create して利用できます。
+ */
+class SimpleBBS
+{
+    private BoardManager $boardManager;
+    private ThreadManager $threadManager;
+    private SystemManager $systemManager;
+
+    private BoardService $boardService;
+    private ThreadService $threadService;
+
+    public function __construct(private readonly DatabaseManager $databaseManager)
+    {
+        $boardRepository = new BoardRepository($this->databaseManager);
+        $threadRepository = new ThreadRepository($this->databaseManager);
+
+        $this->boardService = new BoardService($boardRepository);
+        $this->threadService = new ThreadService($threadRepository);
+
+        $this->boardManager = new BoardManager($this->boardService);
+        $this->threadManager = new ThreadManager($this->threadService);
+        $this->systemManager = new SystemManager($this->databaseManager);
+    }
+
+    public static function create(?string $storagePath = null): self
+    {
+        $packageRoot = dirname(__DIR__);
+        $storagePath ??= $packageRoot . '/.storage';
+
+        $databaseManager = new DatabaseManager($storagePath);
+
+        return new self($databaseManager);
+    }
+
+    public static function boot(string $storagePath): self
+    {
+        return self::create($storagePath);
+    }
+
+    public function boards(): BoardManager
+    {
+        return $this->boardManager;
+    }
+
+    public function threads(): ThreadManager
+    {
+        return $this->threadManager;
+    }
+
+    public function system(): SystemManager
+    {
+        return $this->systemManager;
+    }
+
+    public function database(): DatabaseManager
+    {
+        return $this->databaseManager;
+    }
+
+    public function boardService(): BoardService
+    {
+        return $this->boardService;
+    }
+
+    public function threadService(): ThreadService
+    {
+        return $this->threadService;
+    }
+}

--- a/src/Support/DatabaseManager.php
+++ b/src/Support/DatabaseManager.php
@@ -19,6 +19,11 @@ class DatabaseManager
         }
     }
 
+    public function getDataPath(): string
+    {
+        return $this->dataPath;
+    }
+
     public function getSystemConnection(): PDO
     {
         if ($this->systemConnection instanceof PDO) {

--- a/src/Threads/ThreadManager.php
+++ b/src/Threads/ThreadManager.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SimpleBBS\Threads;
+
+use SimpleBBS\Services\ThreadService;
+
+/**
+ * スレッドおよび投稿操作を提供するファサードクラス。
+ */
+class ThreadManager
+{
+    public function __construct(private readonly ThreadService $service)
+    {
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function listThreads(string $boardSlug): array
+    {
+        return $this->service->listThreads($boardSlug);
+    }
+
+    public function createThread(string $boardSlug, string $title, string $authorName, string $body): int
+    {
+        return $this->service->createThread($boardSlug, $title, $authorName, $body);
+    }
+
+    public function addPost(string $boardSlug, int $threadId, string $authorName, string $body): void
+    {
+        $this->service->addPost($boardSlug, $threadId, $authorName, $body);
+    }
+
+    public function getThread(string $boardSlug, int $threadId): array
+    {
+        return $this->service->getThread($boardSlug, $threadId);
+    }
+
+    public function service(): ThreadService
+    {
+        return $this->service;
+    }
+}


### PR DESCRIPTION
## 概要
- ボード・スレッド・システム管理向けのファサードクラスを追加し、`SimpleBBS` エントリポイントから取得できるようにしました
- アプリケーション初期化処理と各コントローラを新しいマネージャークラス経由で動作するよう更新しました
- README に外部システムからの利用例を追加し、`public/index.php` での初期化手順を整理しました

## テスト
- php -l public/index.php
- php -l src/Application.php
- php -l src/SimpleBBS.php


------
https://chatgpt.com/codex/tasks/task_e_68dcd2d4ff2083308b9923db49afb6cd