### PR TITLE
Composerなし環境向けオートローダーを追加

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,7 +4,14 @@ use SimpleBBS\Application;
 use SimpleBBS\Http\Request;
 use SimpleBBS\SimpleBBS;
 
-require_once __DIR__ . '/../vendor/autoload.php';
+$composerAutoload = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($composerAutoload)) {
+    require_once $composerAutoload;
+}
+
+if (!class_exists(SimpleBBS::class)) {
+    require_once __DIR__ . '/../src/autoload.php';
+}
 
 $storagePath = getenv('SIMPLEBBS_STORAGE_PATH') ?: __DIR__ . '/../.storage';
 

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,17 @@
+<?php
+
+spl_autoload_register(static function (string $class): void {
+    $prefix = 'SimpleBBS\\';
+
+    if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
+        return;
+    }
+
+    $relativeClass = substr($class, strlen($prefix));
+    $relativePath = str_replace('\\', DIRECTORY_SEPARATOR, $relativeClass) . '.php';
+    $file = __DIR__ . DIRECTORY_SEPARATOR . $relativePath;
+
+    if (is_file($file)) {
+        require_once $file;
+    }
+});


### PR DESCRIPTION
## 概要
- Composer のオートローダーが存在する場合のみ読み込むように public/index.php を修正
- SimpleBBS 名前空間に対する簡易オートローダーを src/autoload.php として追加

## テスト
- php -l public/index.php
- php -l src/autoload.php

------
https://chatgpt.com/codex/tasks/task_e_68dcd4c275b083309debe87fd3f29c5f