### PR TITLE
Googleログイン対応と外部認証統合機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,26 @@ composer require simplebbs/simple-bbs
 `public/index.php` では `SimpleBBS\\Application` を生成し、HTTP リクエストを処理します。設置先で Twig のカスタマイズを行いたい場合は、
 `SimpleBBS\\Application::create()` の第 2 引数以降に Twig Environment やビューのパスを渡してください。
 
+### 認証設定
+
+simpleBBS はログイン必須です。スタンドアロンで利用する場合は Google OAuth クライアントを用意し、以下の環境変数を設定してください。
+
+- `SIMPLEBBS_GOOGLE_CLIENT_ID`
+- `SIMPLEBBS_GOOGLE_CLIENT_SECRET`
+- `SIMPLEBBS_GOOGLE_REDIRECT_URI` (例: `https://example.com/index.php?route=auth.callback`)
+
+他システムに組み込んで利用する場合は、`SimpleBBS\Auth\PreAuthenticatedAuthenticator` を利用して認証済みユーザー情報を渡してください。
+
+```php
+use SimpleBBS\Auth\PreAuthenticatedAuthenticator;
+use SimpleBBS\Auth\User;
+use SimpleBBS\Application;
+
+$user = new User('123', '山田 太郎', 'taro@example.com');
+$authenticator = new PreAuthenticatedAuthenticator($user);
+$app = Application::create(authenticator: $authenticator);
+```
+
 ## 他システムからの利用
 
 `SimpleBBS\\SimpleBBS` を生成することで、ボードやスレッド操作用のファサードクラスに直接アクセスできます。

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "library",
     "require": {
         "php": ">=8.1",
-        "twig/twig": "^3.0"
+        "twig/twig": "^3.0",
+        "league/oauth2-google": "^4.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,6 +7,7 @@ SQLite データベースを持つ構成で、別サイトへの組み込みを�
 ## ディレクトリ構成
 ```
 src/
+  Auth/                 ... 認証ユーザーや認証方式を管理
   Application.php        ... 依存解決とルーティングを担うエントリポイント
   Controllers/          ... HTTP コントローラ層
   Core/                 ... ルーターなどコアコンポーネント
@@ -44,6 +45,11 @@ docs/                   ... ドキュメント
 - `boards/index.twig` でボード一覧・作成フォーム、`boards/show.twig` でスレッド一覧・作成フォーム、`threads/show.twig` で投稿表示
 と投稿フォームを表示します。
 - フロントエンドは `public/css/main.css` の軽量スタイルのみを使用。
+
+## 認証
+- `Auth\AuthManager` がリクエストごとの認証状態を判定し、Twig へログイン中のユーザー情報を共有します。
+- スタンドアロン利用時は `Auth\GoogleAuthenticator` が Google OAuth 2.0 を利用してセッションにユーザー情報を保存します。
+- 他システム組み込み時は `Auth\PreAuthenticatedAuthenticator` により外部で認証済みの `Auth\User` を注入できます。
 
 ## ルーティング
 `SimpleBBS\Application` が `Router` に以下のルートを定義します。

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -39,6 +39,20 @@ a:hover {
     margin: 0 auto;
 }
 
+.l-header__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.l-header__brand {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
 .l-header__title {
     margin: 0;
     font-size: 1.8rem;
@@ -47,6 +61,21 @@ a:hover {
 .l-header__description {
     margin: 0.5rem 0 0;
     color: var(--color-muted);
+}
+
+.l-header__user {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-left: auto;
+}
+
+.l-header__user-name {
+    font-weight: 600;
+}
+
+.l-header__logout {
+    margin: 0;
 }
 
 .l-main {
@@ -102,6 +131,14 @@ a:hover {
     gap: 0.5rem;
 }
 
+.c-form__row--static {
+    font-weight: 600;
+}
+
+.c-form__row--static strong {
+    color: var(--color-primary);
+}
+
 .c-form label {
     font-weight: 600;
 }
@@ -131,6 +168,13 @@ a:hover {
 
 .c-button:hover {
     opacity: 0.9;
+}
+
+.c-button--link {
+    background: transparent;
+    color: var(--color-primary);
+    padding: 0;
+    border: none;
 }
 
 .c-board-list,

--- a/resources/views/auth/login.twig
+++ b/resources/views/auth/login.twig
@@ -1,0 +1,27 @@
+{% extends 'base.twig' %}
+
+{% block title %}ログイン | simpleBBS{% endblock %}
+
+{% block content %}
+<section class="c-panel">
+    <h2 class="c-panel__title">ログインが必要です</h2>
+    {% if errors is not empty %}
+        <div class="c-alert">
+            <ul>
+                {% for error in errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    {% if login.message is defined %}
+        <p>{{ login.message }}</p>
+    {% endif %}
+
+    {% if login.loginRoute is defined %}
+        <p>Googleアカウントでログインしてください。</p>
+        <a href="{{ login.loginRoute }}" class="c-button">Googleでログイン</a>
+    {% endif %}
+</section>
+{% endblock %}

--- a/resources/views/base.twig
+++ b/resources/views/base.twig
@@ -9,8 +9,20 @@
 <body>
 <header class="l-header">
     <div class="l-header__inner">
-        <h1 class="l-header__title"><a href="?route=boards.index">simpleBBS</a></h1>
-        <p class="l-header__description">ボードとスレッドで構成されたシンプルなBBS</p>
+        <div class="l-header__brand">
+            <h1 class="l-header__title"><a href="?route=boards.index">simpleBBS</a></h1>
+            <p class="l-header__description">ボードとスレッドで構成されたシンプルなBBS</p>
+        </div>
+        <div class="l-header__user">
+            {% if authUser %}
+                <span class="l-header__user-name">{{ authUser.name }}</span>
+                <form method="post" action="?route=auth.logout" class="l-header__logout">
+                    <button type="submit" class="c-button c-button--link">ログアウト</button>
+                </form>
+            {% else %}
+                <a href="?route=auth.login" class="c-button">ログイン</a>
+            {% endif %}
+        </div>
     </div>
 </header>
 <main class="l-main">

--- a/resources/views/boards/show.twig
+++ b/resources/views/boards/show.twig
@@ -47,10 +47,7 @@
             <label for="thread-title">タイトル</label>
             <input type="text" id="thread-title" name="title" value="{{ old.thread.title|default('') }}" required>
         </div>
-        <div class="c-form__row">
-            <label for="thread-author">投稿者</label>
-            <input type="text" id="thread-author" name="author_name" value="{{ old.thread.author_name|default('') }}" required>
-        </div>
+        <div class="c-form__row c-form__row--static">投稿者: <strong>{{ authUser.name }}</strong></div>
         <div class="c-form__row">
             <label for="thread-body">本文</label>
             <textarea id="thread-body" name="body" rows="5" required>{{ old.thread.body|default('') }}</textarea>

--- a/resources/views/threads/show.twig
+++ b/resources/views/threads/show.twig
@@ -42,10 +42,7 @@
         </div>
     {% endif %}
     <form method="post" action="?route=threads.posts.store&slug={{ board.slug }}&thread={{ thread.id }}" class="c-form">
-        <div class="c-form__row">
-            <label for="post-author">投稿者</label>
-            <input type="text" id="post-author" name="author_name" value="{{ old.author_name|default('') }}" required>
-        </div>
+        <div class="c-form__row c-form__row--static">投稿者: <strong>{{ authUser.name }}</strong></div>
         <div class="c-form__row">
             <label for="post-body">本文</label>
             <textarea id="post-body" name="body" rows="5" required>{{ old.body|default('') }}</textarea>

--- a/src/Auth/AuthManager.php
+++ b/src/Auth/AuthManager.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SimpleBBS\Auth;
+
+use SimpleBBS\Http\Request;
+
+class AuthManager
+{
+    public function __construct(private readonly AuthenticatorInterface $authenticator)
+    {
+    }
+
+    public function user(Request $request): ?User
+    {
+        return $this->authenticator->currentUser($request);
+    }
+
+    public function check(Request $request): bool
+    {
+        return $this->user($request) !== null;
+    }
+
+    public function supportsLoginRedirect(): bool
+    {
+        return $this->authenticator->supportsLoginRedirect();
+    }
+
+    public function initiateLogin(Request $request): void
+    {
+        $this->authenticator->initiateLogin($request);
+    }
+
+    public function handleCallback(Request $request): ?User
+    {
+        return $this->authenticator->handleCallback($request);
+    }
+
+    public function logout(Request $request): void
+    {
+        $this->authenticator->logout($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function loginViewData(): array
+    {
+        return $this->authenticator->loginViewData();
+    }
+}

--- a/src/Auth/AuthenticatorInterface.php
+++ b/src/Auth/AuthenticatorInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SimpleBBS\Auth;
+
+use SimpleBBS\Http\Request;
+
+interface AuthenticatorInterface
+{
+    public function currentUser(Request $request): ?User;
+
+    public function supportsLoginRedirect(): bool;
+
+    public function initiateLogin(Request $request): void;
+
+    public function handleCallback(Request $request): ?User;
+
+    public function logout(Request $request): void;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function loginViewData(): array;
+}

--- a/src/Auth/GoogleAuthenticator.php
+++ b/src/Auth/GoogleAuthenticator.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace SimpleBBS\Auth;
+
+use League\OAuth2\Client\Provider\Google;
+use SimpleBBS\Http\Request;
+
+class GoogleAuthenticator implements AuthenticatorInterface
+{
+    private Google $provider;
+
+    public function __construct(string $clientId, string $clientSecret, string $redirectUri)
+    {
+        $this->provider = new Google([
+            'clientId' => $clientId,
+            'clientSecret' => $clientSecret,
+            'redirectUri' => $redirectUri,
+        ]);
+    }
+
+    public function currentUser(Request $request): ?User
+    {
+        $this->ensureSession();
+
+        $data = $_SESSION['simplebbs_user'] ?? null;
+
+        if (!is_array($data)) {
+            return null;
+        }
+
+        return new User(
+            (string)($data['id'] ?? ''),
+            (string)($data['name'] ?? ''),
+            (string)($data['email'] ?? ''),
+            $data['avatar'] ?? null
+        );
+    }
+
+    public function supportsLoginRedirect(): bool
+    {
+        return true;
+    }
+
+    public function initiateLogin(Request $request): void
+    {
+        $this->ensureSession();
+
+        $authorizationUrl = $this->provider->getAuthorizationUrl([
+            'scope' => ['openid', 'profile', 'email'],
+        ]);
+
+        $_SESSION['simplebbs_oauth2_state'] = $this->provider->getState();
+
+        header('Location: ' . $authorizationUrl);
+        exit;
+    }
+
+    public function handleCallback(Request $request): ?User
+    {
+        $this->ensureSession();
+
+        $expectedState = $_SESSION['simplebbs_oauth2_state'] ?? null;
+        $state = $request->query('state');
+
+        if (!$expectedState || $state !== $expectedState) {
+            unset($_SESSION['simplebbs_oauth2_state']);
+
+            return null;
+        }
+
+        $code = $request->query('code');
+
+        if (!$code) {
+            return null;
+        }
+
+        try {
+            $token = $this->provider->getAccessToken('authorization_code', [
+                'code' => $code,
+            ]);
+            $owner = $this->provider->getResourceOwner($token);
+
+            $user = new User(
+                (string)$owner->getId(),
+                (string)$owner->getName(),
+                (string)$owner->getEmail(),
+                $owner->getAvatar()
+            );
+
+            $_SESSION['simplebbs_user'] = [
+                'id' => $user->getId(),
+                'name' => $user->getName(),
+                'email' => $user->getEmail(),
+                'avatar' => $user->getAvatarUrl(),
+            ];
+
+            unset($_SESSION['simplebbs_oauth2_state']);
+
+            return $user;
+        } catch (\Throwable $exception) {
+            return null;
+        }
+    }
+
+    public function logout(Request $request): void
+    {
+        $this->ensureSession();
+
+        unset($_SESSION['simplebbs_user'], $_SESSION['simplebbs_oauth2_state']);
+    }
+
+    public function loginViewData(): array
+    {
+        return [
+            'loginRoute' => '?route=auth.redirect',
+        ];
+    }
+
+    private function ensureSession(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+    }
+}

--- a/src/Auth/PreAuthenticatedAuthenticator.php
+++ b/src/Auth/PreAuthenticatedAuthenticator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SimpleBBS\Auth;
+
+use SimpleBBS\Http\Request;
+
+class PreAuthenticatedAuthenticator implements AuthenticatorInterface
+{
+    public function __construct(private readonly User $user)
+    {
+    }
+
+    public function currentUser(Request $request): ?User
+    {
+        return $this->user;
+    }
+
+    public function supportsLoginRedirect(): bool
+    {
+        return false;
+    }
+
+    public function initiateLogin(Request $request): void
+    {
+        // 組み込み利用時は外部システムで認証済みの想定のため特別な処理は不要
+    }
+
+    public function handleCallback(Request $request): ?User
+    {
+        return $this->user;
+    }
+
+    public function logout(Request $request): void
+    {
+        // 外部システムで管理されるため、ここでは何もしない
+    }
+
+    public function loginViewData(): array
+    {
+        return [
+            'message' => '外部システムから利用されています。',
+        ];
+    }
+}

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SimpleBBS\Auth;
+
+class User
+{
+    public function __construct(
+        private readonly string $id,
+        private readonly string $name,
+        private readonly string $email,
+        private readonly ?string $avatarUrl = null
+    ) {
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getAvatarUrl(): ?string
+    {
+        return $this->avatarUrl;
+    }
+}

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SimpleBBS\Controllers;
+
+use SimpleBBS\Auth\AuthManager;
+use SimpleBBS\Http\Request;
+use Twig\Environment;
+
+class AuthController
+{
+    public function __construct(
+        private readonly Environment $view,
+        private readonly AuthManager $authManager
+    ) {
+    }
+
+    public function login(Request $request): string
+    {
+        if ($this->authManager->check($request)) {
+            header('Location: ?route=boards.index');
+            exit;
+        }
+
+        return $this->view->render('auth/login.twig', [
+            'errors' => [],
+            'login' => $this->authManager->loginViewData(),
+        ]);
+    }
+
+    public function redirect(Request $request): void
+    {
+        if (!$this->authManager->supportsLoginRedirect()) {
+            header('Location: ?route=boards.index');
+            exit;
+        }
+
+        $this->authManager->initiateLogin($request);
+    }
+
+    public function callback(Request $request): void
+    {
+        $user = $this->authManager->handleCallback($request);
+
+        if ($user) {
+            header('Location: ?route=boards.index');
+            exit;
+        }
+
+        echo $this->view->render('auth/login.twig', [
+            'errors' => ['Googleログインに失敗しました。'],
+            'login' => $this->authManager->loginViewData(),
+        ]);
+    }
+
+    public function logout(Request $request): void
+    {
+        $this->authManager->logout($request);
+        header('Location: ?route=auth.login');
+        exit;
+    }
+}

--- a/src/Controllers/ThreadController.php
+++ b/src/Controllers/ThreadController.php
@@ -6,6 +6,7 @@ use SimpleBBS\Boards\BoardManager;
 use SimpleBBS\Http\Request;
 use SimpleBBS\Threads\ThreadManager;
 use InvalidArgumentException;
+use RuntimeException;
 use Twig\Environment;
 
 class ThreadController
@@ -21,12 +22,17 @@ class ThreadController
     {
         $slug = (string)$request->query('slug');
         $board = $this->boardManager->getBoard($slug);
+        $user = $request->user();
+
+        if (!$user) {
+            throw new RuntimeException('ログインが必要です。');
+        }
 
         try {
             $threadId = $this->threadManager->createThread(
                 $board['slug'],
                 (string)$request->input('title'),
-                (string)$request->input('author_name'),
+                $user->getName(),
                 (string)$request->input('body')
             );
 
@@ -41,7 +47,6 @@ class ThreadController
                 'old' => [
                     'thread' => [
                         'title' => $request->input('title'),
-                        'author_name' => $request->input('author_name'),
                         'body' => $request->input('body'),
                     ],
                 ],
@@ -69,12 +74,17 @@ class ThreadController
         $slug = (string)$request->query('slug');
         $threadId = (int)$request->query('thread');
         $board = $this->boardManager->getBoard($slug);
+        $user = $request->user();
+
+        if (!$user) {
+            throw new RuntimeException('ログインが必要です。');
+        }
 
         try {
             $this->threadManager->addPost(
                 $board['slug'],
                 $threadId,
-                (string)$request->input('author_name'),
+                $user->getName(),
                 (string)$request->input('body')
             );
 
@@ -87,7 +97,6 @@ class ThreadController
                 'thread' => $thread,
                 'errors' => [$exception->getMessage()],
                 'old' => [
-                    'author_name' => $request->input('author_name'),
                     'body' => $request->input('body'),
                 ],
             ]);

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -4,6 +4,8 @@ namespace SimpleBBS\Http;
 
 class Request
 {
+    private ?\SimpleBBS\Auth\User $user = null;
+
     public function __construct(
         private readonly string $method,
         private readonly array $query,
@@ -41,5 +43,15 @@ class Request
             'query' => $this->query,
             'body' => $this->body,
         ];
+    }
+
+    public function setUser(?\SimpleBBS\Auth\User $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function user(): ?\SimpleBBS\Auth\User
+    {
+        return $this->user;
     }
 }


### PR DESCRIPTION
## 概要
- Google OAuth 2.0 を利用したログインルートと認証ハンドラを追加し、アプリケーション起動時に必ず認証を経由するようにしました。
- 外部システムから事前認証済みユーザーを受け取れる PreAuthenticatedAuthenticator を追加し、Twig テンプレートやフォームからログインユーザー名を参照できるようにしました。
- ヘッダーや投稿フォームの UI をログイン状態に合わせて調整し、README / ドキュメントに認証手順を追記しました。

## テスト
- `php -l src/Application.php`
- `php -l src/Auth/GoogleAuthenticator.php`
- `php -l src/Controllers/AuthController.php`
- `php -l src/Controllers/ThreadController.php`
- `php -l src/Http/Request.php`
- `php -l src/Auth/AuthManager.php`
- `php -l src/Auth/AuthenticatorInterface.php`
- `php -l src/Auth/User.php`
- `php -l src/Auth/PreAuthenticatedAuthenticator.php`


------
https://chatgpt.com/codex/tasks/task_e_68dcd5520abc8330890641226205a305