### PR TITLE
環境設定ファイル対応と匿名投稿機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,34 @@ composer require simplebbs/simple-bbs
 
 ## セットアップ
 1. Web ルートを `vendor/simplebbs/simple-bbs/public` に向けるか、`public/` ディレクトリの内容を任意の公開ディレクトリに配置します。
-2. `.storage/` ディレクトリを BBS のデータ格納用に書き込み可能へ設定するか、環境変数 `SIMPLEBBS_STORAGE_PATH` で任意の書き込み先パスを指定します。
+2. `.storage/` ディレクトリを BBS のデータ格納用に書き込み可能へ設定するか、`.env` (または環境変数 `SIMPLEBBS_STORAGE_PATH`) で任意の書き込み先パスを指定します。設定例は `sample.env` を参照してください。
 3. ブラウザでアクセスすると、ボード作成からスレッド・投稿まで利用できます。
 
 `public/index.php` では `SimpleBBS\\Application` を生成し、HTTP リクエストを処理します。設置先で Twig のカスタマイズを行いたい場合は、
 `SimpleBBS\\Application::create()` の第 2 引数以降に Twig Environment やビューのパスを渡してください。
 
+### 設定項目
+
+`.env` または環境変数で以下の項目を設定できます。未指定の場合は既定値が使用されます。
+
+- `SIMPLEBBS_REQUIRE_LOGIN` (既定値: `false`)
+  - `true` の場合はログイン必須となり、認証の設定がないとアプリケーションが起動しません。
+- `SIMPLEBBS_ALLOW_ANONYMOUS_POST` (既定値: `true`)
+  - 匿名でのスレッド作成・投稿を許可します。`false` にすると未ログイン時は投稿できません。
+- `SIMPLEBBS_ALLOW_USER_BOARD_CREATION` (既定値: `true`)
+  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。
+
 ### 認証設定
 
-simpleBBS はログイン必須です。スタンドアロンで利用する場合は Google OAuth クライアントを用意し、以下の環境変数を設定してください。
+ログインを利用する場合は Google OAuth クライアントを用意し、以下の環境変数を設定してください。
 
 - `SIMPLEBBS_GOOGLE_CLIENT_ID`
 - `SIMPLEBBS_GOOGLE_CLIENT_SECRET`
 - `SIMPLEBBS_GOOGLE_REDIRECT_URI` (例: `https://example.com/index.php?route=auth.callback`)
 
 他システムに組み込んで利用する場合は、`SimpleBBS\Auth\PreAuthenticatedAuthenticator` を利用して認証済みユーザー情報を渡してください。
+
+ログインを必須にしない場合は上記の環境変数を設定しなくても動作します。
 
 ```php
 use SimpleBBS\Auth\PreAuthenticatedAuthenticator;

--- a/public/index.php
+++ b/public/index.php
@@ -3,6 +3,7 @@
 use SimpleBBS\Application;
 use SimpleBBS\Http\Request;
 use SimpleBBS\SimpleBBS;
+use SimpleBBS\Support\Config;
 
 $composerAutoload = __DIR__ . '/../vendor/autoload.php';
 if (file_exists($composerAutoload)) {
@@ -13,8 +14,9 @@ if (!class_exists(SimpleBBS::class)) {
     require_once __DIR__ . '/../src/autoload.php';
 }
 
-$storagePath = getenv('SIMPLEBBS_STORAGE_PATH') ?: __DIR__ . '/../.storage';
+$config = Config::load(__DIR__ . '/../.env');
+$storagePath = $config->storagePath(__DIR__ . '/../.storage');
 
 $bbs = SimpleBBS::create($storagePath);
-$app = Application::create(storagePath: $storagePath, bbs: $bbs);
+$app = Application::create(storagePath: $storagePath, bbs: $bbs, config: $config);
 $app->handle(Request::fromGlobals());

--- a/resources/views/base.twig
+++ b/resources/views/base.twig
@@ -19,7 +19,7 @@
                 <form method="post" action="?route=auth.logout" class="l-header__logout">
                     <button type="submit" class="c-button c-button--link">ログアウト</button>
                 </form>
-            {% else %}
+            {% elseif authSupportsLogin %}
                 <a href="?route=auth.login" class="c-button">ログイン</a>
             {% endif %}
         </div>

--- a/resources/views/boards/index.twig
+++ b/resources/views/boards/index.twig
@@ -26,31 +26,35 @@
 
 <section class="c-panel">
     <h2 class="c-panel__title">新規ボード作成</h2>
-    {% if errors is not empty %}
-        <div class="c-alert">
-            <ul>
-                {% for error in errors %}
-                    <li>{{ error }}</li>
-                {% endfor %}
-            </ul>
-        </div>
+    {% if features.allowUserBoardCreation %}
+        {% if errors is not empty %}
+            <div class="c-alert">
+                <ul>
+                    {% for error in errors %}
+                        <li>{{ error }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+        <form method="post" action="?route=boards.store" class="c-form">
+            <div class="c-form__row">
+                <label for="title">ボード名</label>
+                <input type="text" id="title" name="title" value="{{ old.title|default('') }}" required>
+            </div>
+            <div class="c-form__row">
+                <label for="slug">スラッグ (URL識別子)</label>
+                <input type="text" id="slug" name="slug" value="{{ old.slug|default('') }}" placeholder="未入力の場合はボード名から自動生成">
+            </div>
+            <div class="c-form__row">
+                <label for="description">説明</label>
+                <textarea id="description" name="description" rows="3">{{ old.description|default('') }}</textarea>
+            </div>
+            <div class="c-form__actions">
+                <button type="submit" class="c-button">作成</button>
+            </div>
+        </form>
+    {% else %}
+        <p>現在は新しいボードの作成が制限されています。</p>
     {% endif %}
-    <form method="post" action="?route=boards.store" class="c-form">
-        <div class="c-form__row">
-            <label for="title">ボード名</label>
-            <input type="text" id="title" name="title" value="{{ old.title|default('') }}" required>
-        </div>
-        <div class="c-form__row">
-            <label for="slug">スラッグ (URL識別子)</label>
-            <input type="text" id="slug" name="slug" value="{{ old.slug|default('') }}" placeholder="未入力の場合はボード名から自動生成">
-        </div>
-        <div class="c-form__row">
-            <label for="description">説明</label>
-            <textarea id="description" name="description" rows="3">{{ old.description|default('') }}</textarea>
-        </div>
-        <div class="c-form__actions">
-            <button type="submit" class="c-button">作成</button>
-        </div>
-    </form>
 </section>
 {% endblock %}

--- a/resources/views/boards/show.twig
+++ b/resources/views/boards/show.twig
@@ -42,19 +42,30 @@
             </ul>
         </div>
     {% endif %}
-    <form method="post" action="?route=threads.store&slug={{ board.slug }}" class="c-form">
-        <div class="c-form__row">
-            <label for="thread-title">タイトル</label>
-            <input type="text" id="thread-title" name="title" value="{{ old.thread.title|default('') }}" required>
-        </div>
-        <div class="c-form__row c-form__row--static">投稿者: <strong>{{ authUser.name }}</strong></div>
-        <div class="c-form__row">
-            <label for="thread-body">本文</label>
-            <textarea id="thread-body" name="body" rows="5" required>{{ old.thread.body|default('') }}</textarea>
-        </div>
-        <div class="c-form__actions">
-            <button type="submit" class="c-button">作成</button>
-        </div>
-    </form>
+    {% if authUser or features.allowAnonymousPosting %}
+        <form method="post" action="?route=threads.store&slug={{ board.slug }}" class="c-form">
+            <div class="c-form__row">
+                <label for="thread-title">タイトル</label>
+                <input type="text" id="thread-title" name="title" value="{{ old.thread.title|default('') }}" required>
+            </div>
+            {% if authUser %}
+                <div class="c-form__row c-form__row--static">投稿者: <strong>{{ authUser.name }}</strong></div>
+            {% else %}
+                <div class="c-form__row">
+                    <label for="thread-author">投稿者名</label>
+                    <input type="text" id="thread-author" name="author_name" value="{{ old.thread.author_name|default('') }}" placeholder="未入力の場合は『名無しさん』">
+                </div>
+            {% endif %}
+            <div class="c-form__row">
+                <label for="thread-body">本文</label>
+                <textarea id="thread-body" name="body" rows="5" required>{{ old.thread.body|default('') }}</textarea>
+            </div>
+            <div class="c-form__actions">
+                <button type="submit" class="c-button">作成</button>
+            </div>
+        </form>
+    {% else %}
+        <p>スレッドを作成するにはログインしてください。</p>
+    {% endif %}
 </section>
 {% endblock %}

--- a/resources/views/threads/show.twig
+++ b/resources/views/threads/show.twig
@@ -41,15 +41,26 @@
             </ul>
         </div>
     {% endif %}
-    <form method="post" action="?route=threads.posts.store&slug={{ board.slug }}&thread={{ thread.id }}" class="c-form">
-        <div class="c-form__row c-form__row--static">投稿者: <strong>{{ authUser.name }}</strong></div>
-        <div class="c-form__row">
-            <label for="post-body">本文</label>
-            <textarea id="post-body" name="body" rows="5" required>{{ old.body|default('') }}</textarea>
-        </div>
-        <div class="c-form__actions">
-            <button type="submit" class="c-button">送信</button>
-        </div>
-    </form>
+    {% if authUser or features.allowAnonymousPosting %}
+        <form method="post" action="?route=threads.posts.store&slug={{ board.slug }}&thread={{ thread.id }}" class="c-form">
+            {% if authUser %}
+                <div class="c-form__row c-form__row--static">投稿者: <strong>{{ authUser.name }}</strong></div>
+            {% else %}
+                <div class="c-form__row">
+                    <label for="post-author">投稿者名</label>
+                    <input type="text" id="post-author" name="author_name" value="{{ old.author_name|default('') }}" placeholder="未入力の場合は『名無しさん』">
+                </div>
+            {% endif %}
+            <div class="c-form__row">
+                <label for="post-body">本文</label>
+                <textarea id="post-body" name="body" rows="5" required>{{ old.body|default('') }}</textarea>
+            </div>
+            <div class="c-form__actions">
+                <button type="submit" class="c-button">送信</button>
+            </div>
+        </form>
+    {% else %}
+        <p>投稿するにはログインしてください。</p>
+    {% endif %}
 </section>
 {% endblock %}

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,14 @@
+# simpleBBS の設定サンプル
+# このファイルを .env にコピーして値を調整してください。
+
+# ストレージディレクトリのパス (未指定の場合はプロジェクト直下の .storage を使用)
+#SIMPLEBBS_STORAGE_PATH=/absolute/path/to/storage
+
+# ログインを必須にするかどうか (true/false)
+SIMPLEBBS_REQUIRE_LOGIN=false
+
+# 匿名投稿を許可するかどうか (true/false)
+SIMPLEBBS_ALLOW_ANONYMOUS_POST=true
+
+# ユーザーによるボード作成を許可するかどうか (true/false)
+SIMPLEBBS_ALLOW_USER_BOARD_CREATION=true

--- a/src/Auth/GuestAuthenticator.php
+++ b/src/Auth/GuestAuthenticator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SimpleBBS\Auth;
+
+use SimpleBBS\Http\Request;
+
+class GuestAuthenticator implements AuthenticatorInterface
+{
+    public function currentUser(Request $request): ?User
+    {
+        return null;
+    }
+
+    public function supportsLoginRedirect(): bool
+    {
+        return false;
+    }
+
+    public function initiateLogin(Request $request): void
+    {
+        // ゲストモードでは何もしません。
+    }
+
+    public function handleCallback(Request $request): ?User
+    {
+        return null;
+    }
+
+    public function logout(Request $request): void
+    {
+        // ゲストモードでは特に処理はありません。
+    }
+
+    public function loginViewData(): array
+    {
+        return [
+            'message' => 'ログイン機能は無効化されています。',
+        ];
+    }
+}

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -55,7 +55,8 @@ class AuthController
     public function logout(Request $request): void
     {
         $this->authManager->logout($request);
-        header('Location: ?route=auth.login');
+        $target = $this->authManager->supportsLoginRedirect() ? '?route=auth.login' : '?route=boards.index';
+        header('Location: ' . $target);
         exit;
     }
 }

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace SimpleBBS\Support;
+
+class Config
+{
+    private const DEFAULTS = [
+        'require_login' => false,
+        'allow_anonymous_posting' => true,
+        'allow_user_board_creation' => true,
+    ];
+
+    /**
+     * @param array<string, mixed> $settings
+     */
+    public function __construct(private array $settings)
+    {
+        $this->settings = array_merge(self::DEFAULTS, $this->settings);
+    }
+
+    public static function load(?string $envPath = null): self
+    {
+        if ($envPath) {
+            self::applyEnvFile($envPath);
+        }
+
+        return self::fromEnvironment();
+    }
+
+    public static function fromEnvironment(): self
+    {
+        $settings = [];
+
+        $requireLogin = getenv('SIMPLEBBS_REQUIRE_LOGIN');
+        if ($requireLogin !== false) {
+            $settings['require_login'] = self::toBool($requireLogin);
+        }
+
+        $allowAnonymous = getenv('SIMPLEBBS_ALLOW_ANONYMOUS_POST');
+        if ($allowAnonymous !== false) {
+            $settings['allow_anonymous_posting'] = self::toBool($allowAnonymous);
+        }
+
+        $allowBoardCreation = getenv('SIMPLEBBS_ALLOW_USER_BOARD_CREATION');
+        if ($allowBoardCreation !== false) {
+            $settings['allow_user_board_creation'] = self::toBool($allowBoardCreation);
+        }
+
+        $storagePath = getenv('SIMPLEBBS_STORAGE_PATH');
+        if ($storagePath !== false) {
+            $settings['storage_path'] = $storagePath;
+        }
+
+        return new self($settings);
+    }
+
+    public function requiresLogin(): bool
+    {
+        return (bool)$this->settings['require_login'];
+    }
+
+    public function allowsAnonymousPosting(): bool
+    {
+        return (bool)$this->settings['allow_anonymous_posting'];
+    }
+
+    public function allowsUserBoardCreation(): bool
+    {
+        return (bool)$this->settings['allow_user_board_creation'];
+    }
+
+    public function storagePath(string $default): string
+    {
+        return isset($this->settings['storage_path']) && $this->settings['storage_path'] !== ''
+            ? (string)$this->settings['storage_path']
+            : $default;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->settings;
+    }
+
+    private static function toBool(string $value): bool
+    {
+        $normalized = strtolower(trim($value));
+
+        if ($normalized === '') {
+            return false;
+        }
+
+        return in_array($normalized, ['1', 'true', 'on', 'yes'], true);
+    }
+
+    private static function applyEnvFile(string $envPath): void
+    {
+        if (!is_file($envPath)) {
+            return;
+        }
+
+        $lines = file($envPath, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        if ($lines === false) {
+            return;
+        }
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            if (!str_contains($line, '=')) {
+                continue;
+            }
+
+            [$key, $value] = explode('=', $line, 2);
+            $key = trim($key);
+            $value = trim($value);
+
+            if ($key === '') {
+                continue;
+            }
+
+            if ($value !== '' && ($value[0] === '"' || $value[0] === '\'')) {
+                $quote = $value[0];
+                if (str_ends_with($value, $quote)) {
+                    $value = substr($value, 1, -1);
+                }
+            }
+
+            putenv(sprintf('%s=%s', $key, $value));
+            $_ENV[$key] = $value;
+            $_SERVER[$key] = $value;
+        }
+    }
+}


### PR DESCRIPTION
## 概要
- .env から設定値を読み込む Config クラスを追加し、sample.env を提供
- ログイン必須・匿名投稿・ボード作成可否を設定で切り替えられるようにし、未設定時はゲストモードで動作
- Twig テンプレートを設定に応じて表示を変更し、ドキュメントを更新

## テスト
- php -l src/Support/Config.php
- php -l src/Auth/GuestAuthenticator.php
- php -l src/Application.php
- php -l src/Controllers/AuthController.php
- php -l src/Controllers/BoardController.php
- php -l src/Controllers/ThreadController.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68dcdcd9527c83308a89f4a92e32aec4