### PR TITLE
ボード作成のログイン必須化とサンプル環境変数の統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ composer require simplebbs/simple-bbs
 - `SIMPLEBBS_ALLOW_ANONYMOUS_POST` (既定値: `true`)
   - 匿名でのスレッド作成・投稿を許可します。`false` にすると未ログイン時は投稿できません。
 - `SIMPLEBBS_ALLOW_USER_BOARD_CREATION` (既定値: `true`)
-  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。
+  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。設定値に関わらず、ボード作成を行うにはログインが必要です。
 
 ### 認証設定
 

--- a/resources/views/boards/index.twig
+++ b/resources/views/boards/index.twig
@@ -26,33 +26,37 @@
 
 <section class="c-panel">
     <h2 class="c-panel__title">新規ボード作成</h2>
+    {% if errors is not empty %}
+        <div class="c-alert">
+            <ul>
+                {% for error in errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
     {% if features.allowUserBoardCreation %}
-        {% if errors is not empty %}
-            <div class="c-alert">
-                <ul>
-                    {% for error in errors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
+        {% if authUser %}
+            <form method="post" action="?route=boards.store" class="c-form">
+                <div class="c-form__row">
+                    <label for="title">ボード名</label>
+                    <input type="text" id="title" name="title" value="{{ old.title|default('') }}" required>
+                </div>
+                <div class="c-form__row">
+                    <label for="slug">スラッグ (URL識別子)</label>
+                    <input type="text" id="slug" name="slug" value="{{ old.slug|default('') }}" placeholder="未入力の場合はボード名から自動生成">
+                </div>
+                <div class="c-form__row">
+                    <label for="description">説明</label>
+                    <textarea id="description" name="description" rows="3">{{ old.description|default('') }}</textarea>
+                </div>
+                <div class="c-form__actions">
+                    <button type="submit" class="c-button">作成</button>
+                </div>
+            </form>
+        {% else %}
+            <p>ボードを作成するにはログインしてください。</p>
         {% endif %}
-        <form method="post" action="?route=boards.store" class="c-form">
-            <div class="c-form__row">
-                <label for="title">ボード名</label>
-                <input type="text" id="title" name="title" value="{{ old.title|default('') }}" required>
-            </div>
-            <div class="c-form__row">
-                <label for="slug">スラッグ (URL識別子)</label>
-                <input type="text" id="slug" name="slug" value="{{ old.slug|default('') }}" placeholder="未入力の場合はボード名から自動生成">
-            </div>
-            <div class="c-form__row">
-                <label for="description">説明</label>
-                <textarea id="description" name="description" rows="3">{{ old.description|default('') }}</textarea>
-            </div>
-            <div class="c-form__actions">
-                <button type="submit" class="c-button">作成</button>
-            </div>
-        </form>
     {% else %}
         <p>現在は新しいボードの作成が制限されています。</p>
     {% endif %}

--- a/sample.env
+++ b/sample.env
@@ -5,10 +5,11 @@
 #SIMPLEBBS_STORAGE_PATH=/absolute/path/to/storage
 
 # ログインを必須にするかどうか (true/false)
-MUST_LOGIN=false
+SIMPLEBBS_REQUIRE_LOGIN=false
 
 # 匿名投稿を許可するかどうか (true/false)
-ANONYMOUS_POST=true
+SIMPLEBBS_ALLOW_ANONYMOUS_POST=true
 
 # ユーザーによるボード作成を許可するかどうか (true/false)
-USER_BOARD_CREAT=true
+# ボード作成はログイン済みのユーザーのみが実行できます。
+SIMPLEBBS_ALLOW_USER_BOARD_CREATION=true

--- a/src/Controllers/BoardController.php
+++ b/src/Controllers/BoardController.php
@@ -41,6 +41,16 @@ class BoardController
             return;
         }
 
+        if ($request->user() === null) {
+            http_response_code(403);
+            $boards = $this->boardManager->listBoards();
+            echo $this->view->render('boards/index.twig', [
+                'boards' => $boards,
+                'errors' => ['ボードを作成するにはログインが必要です。'],
+            ]);
+            return;
+        }
+
         try {
             $board = $this->boardManager->createBoard(
                 (string)$request->input('title'),


### PR DESCRIPTION
## 概要
- sample.env の変数名を実装と一致する SIMPLEBBS_* 系にそろえ、ボード作成がログイン前提である旨を明記
- ボード作成処理で未ログイン時は 403 を返し、テンプレートではフォームを非表示にしてログインを促すように調整
- README の設定説明にボード作成にはログインが必要であることを追記

## テスト
- php -l src/Controllers/BoardController.php

------
https://chatgpt.com/codex/tasks/task_e_68dce04c6728833083db810f5db6d566