### PR TITLE
環境変数の短縮名対応とボード作成時のログイン要件の反映

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ composer require simplebbs/simple-bbs
 
 ### 設定項目
 
-`.env` または環境変数で以下の項目を設定できます。未指定の場合は既定値が使用されます。
+`.env` または環境変数で以下の項目を設定できます。未指定の場合は既定値が使用されます。括弧内は互換性のために引き続き利用できる旧名称です。
 
-- `SIMPLEBBS_REQUIRE_LOGIN` (既定値: `false`)
+- `MUST_LOGIN` (`SIMPLEBBS_REQUIRE_LOGIN`, 既定値: `false`)
   - `true` の場合はログイン必須となり、認証の設定がないとアプリケーションが起動しません。
-- `SIMPLEBBS_ALLOW_ANONYMOUS_POST` (既定値: `true`)
+- `ANONYMOUS_POST` (`SIMPLEBBS_ALLOW_ANONYMOUS_POST`, 既定値: `true`)
   - 匿名でのスレッド作成・投稿を許可します。`false` にすると未ログイン時は投稿できません。
-- `SIMPLEBBS_ALLOW_USER_BOARD_CREATION` (既定値: `true`)
-  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。
+- `USER_BOARD_CREAT` (`SIMPLEBBS_ALLOW_USER_BOARD_CREATION`, 既定値: `true`)
+  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。ボード作成はログイン済みのユーザーのみ利用できます。
 
 ### 認証設定
 

--- a/resources/views/boards/index.twig
+++ b/resources/views/boards/index.twig
@@ -26,16 +26,17 @@
 
 <section class="c-panel">
     <h2 class="c-panel__title">新規ボード作成</h2>
-    {% if features.allowUserBoardCreation %}
-        {% if errors is not empty %}
-            <div class="c-alert">
-                <ul>
-                    {% for error in errors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
-        {% endif %}
+    {% if errors is not empty %}
+        <div class="c-alert">
+            <ul>
+                {% for error in errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    {% if features.allowUserBoardCreation and authUser %}
         <form method="post" action="?route=boards.store" class="c-form">
             <div class="c-form__row">
                 <label for="title">ボード名</label>
@@ -53,8 +54,10 @@
                 <button type="submit" class="c-button">作成</button>
             </div>
         </form>
-    {% else %}
+    {% elseif not features.allowUserBoardCreation %}
         <p>現在は新しいボードの作成が制限されています。</p>
+    {% else %}
+        <p>ボードを作成するにはログインしてください。</p>
     {% endif %}
 </section>
 {% endblock %}

--- a/sample.env
+++ b/sample.env
@@ -10,5 +10,5 @@ MUST_LOGIN=false
 # 匿名投稿を許可するかどうか (true/false)
 ANONYMOUS_POST=true
 
-# ユーザーによるボード作成を許可するかどうか (true/false)
+# ユーザーによるボード作成を許可するかどうか (true/false、ログイン必須)
 USER_BOARD_CREAT=true

--- a/src/Controllers/BoardController.php
+++ b/src/Controllers/BoardController.php
@@ -41,6 +41,16 @@ class BoardController
             return;
         }
 
+        if (!$request->user()) {
+            http_response_code(403);
+            $boards = $this->boardManager->listBoards();
+            echo $this->view->render('boards/index.twig', [
+                'boards' => $boards,
+                'errors' => ['ボードを作成するにはログインが必要です。'],
+            ]);
+            return;
+        }
+
         try {
             $board = $this->boardManager->createBoard(
                 (string)$request->input('title'),

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -31,18 +31,18 @@ class Config
     {
         $settings = [];
 
-        $requireLogin = getenv('SIMPLEBBS_REQUIRE_LOGIN');
-        if ($requireLogin !== false) {
+        $requireLogin = self::getEnvValue(['MUST_LOGIN', 'SIMPLEBBS_REQUIRE_LOGIN']);
+        if ($requireLogin !== null) {
             $settings['require_login'] = self::toBool($requireLogin);
         }
 
-        $allowAnonymous = getenv('SIMPLEBBS_ALLOW_ANONYMOUS_POST');
-        if ($allowAnonymous !== false) {
+        $allowAnonymous = self::getEnvValue(['ANONYMOUS_POST', 'SIMPLEBBS_ALLOW_ANONYMOUS_POST']);
+        if ($allowAnonymous !== null) {
             $settings['allow_anonymous_posting'] = self::toBool($allowAnonymous);
         }
 
-        $allowBoardCreation = getenv('SIMPLEBBS_ALLOW_USER_BOARD_CREATION');
-        if ($allowBoardCreation !== false) {
+        $allowBoardCreation = self::getEnvValue(['USER_BOARD_CREAT', 'SIMPLEBBS_ALLOW_USER_BOARD_CREATION']);
+        if ($allowBoardCreation !== null) {
             $settings['allow_user_board_creation'] = self::toBool($allowBoardCreation);
         }
 
@@ -82,6 +82,19 @@ class Config
     public function toArray(): array
     {
         return $this->settings;
+    }
+
+    private static function getEnvValue(array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = getenv($key);
+
+            if ($value !== false) {
+                return $value;
+            }
+        }
+
+        return null;
     }
 
     private static function toBool(string $value): bool


### PR DESCRIPTION
## 概要
- sample.env で短縮した環境変数名に合わせて Config を更新し、旧名称も引き続き利用できるようにしました
- ボード作成がログイン済みのユーザーのみ行えるようにし、エラー表示と画面メッセージを調整しました
- README を新しい環境変数名とログイン前提の説明に更新しました

## テスト
- php -l src/Support/Config.php
- php -l src/Controllers/BoardController.php

------
https://chatgpt.com/codex/tasks/task_e_68dce04c6728833083db810f5db6d566