### PR TITLE
短縮環境変数への対応とボード作成のログイン必須化

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ composer require simplebbs/simple-bbs
 
 `.env` または環境変数で以下の項目を設定できます。未指定の場合は既定値が使用されます。
 
-- `SIMPLEBBS_REQUIRE_LOGIN` (既定値: `false`)
+- `MUST_LOGIN` (既定値: `false`, 互換性のため `SIMPLEBBS_REQUIRE_LOGIN` も利用可能)
   - `true` の場合はログイン必須となり、認証の設定がないとアプリケーションが起動しません。
-- `SIMPLEBBS_ALLOW_ANONYMOUS_POST` (既定値: `true`)
+- `ANONYMOUS_POST` (既定値: `true`, 互換性のため `SIMPLEBBS_ALLOW_ANONYMOUS_POST` も利用可能)
   - 匿名でのスレッド作成・投稿を許可します。`false` にすると未ログイン時は投稿できません。
-- `SIMPLEBBS_ALLOW_USER_BOARD_CREATION` (既定値: `true`)
-  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。
+- `USER_BOARD_CREATE` (既定値: `true`, 互換性のため `SIMPLEBBS_ALLOW_USER_BOARD_CREATION` も利用可能)
+  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。ボードを作成する際は必ずログインが必要です。
 
 ### 認証設定
 

--- a/resources/views/boards/index.twig
+++ b/resources/views/boards/index.twig
@@ -27,32 +27,39 @@
 <section class="c-panel">
     <h2 class="c-panel__title">新規ボード作成</h2>
     {% if features.allowUserBoardCreation %}
-        {% if errors is not empty %}
-            <div class="c-alert">
-                <ul>
-                    {% for error in errors %}
-                        <li>{{ error }}</li>
-                    {% endfor %}
-                </ul>
-            </div>
+        {% if authUser %}
+            {% if errors is not empty %}
+                <div class="c-alert">
+                    <ul>
+                        {% for error in errors %}
+                            <li>{{ error }}</li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            {% endif %}
+            <form method="post" action="?route=boards.store" class="c-form">
+                <div class="c-form__row">
+                    <label for="title">ボード名</label>
+                    <input type="text" id="title" name="title" value="{{ old.title|default('') }}" required>
+                </div>
+                <div class="c-form__row">
+                    <label for="slug">スラッグ (URL識別子)</label>
+                    <input type="text" id="slug" name="slug" value="{{ old.slug|default('') }}" placeholder="未入力の場合はボード名から自動生成">
+                </div>
+                <div class="c-form__row">
+                    <label for="description">説明</label>
+                    <textarea id="description" name="description" rows="3">{{ old.description|default('') }}</textarea>
+                </div>
+                <div class="c-form__actions">
+                    <button type="submit" class="c-button">作成</button>
+                </div>
+            </form>
+        {% elseif authSupportsLogin %}
+            <p>新しいボードを作成するにはログインしてください。</p>
+            <a href="?route=auth.login" class="c-button">ログイン</a>
+        {% else %}
+            <p>ログイン機能が無効なため、新しいボードを作成できません。</p>
         {% endif %}
-        <form method="post" action="?route=boards.store" class="c-form">
-            <div class="c-form__row">
-                <label for="title">ボード名</label>
-                <input type="text" id="title" name="title" value="{{ old.title|default('') }}" required>
-            </div>
-            <div class="c-form__row">
-                <label for="slug">スラッグ (URL識別子)</label>
-                <input type="text" id="slug" name="slug" value="{{ old.slug|default('') }}" placeholder="未入力の場合はボード名から自動生成">
-            </div>
-            <div class="c-form__row">
-                <label for="description">説明</label>
-                <textarea id="description" name="description" rows="3">{{ old.description|default('') }}</textarea>
-            </div>
-            <div class="c-form__actions">
-                <button type="submit" class="c-button">作成</button>
-            </div>
-        </form>
     {% else %}
         <p>現在は新しいボードの作成が制限されています。</p>
     {% endif %}

--- a/sample.env
+++ b/sample.env
@@ -2,13 +2,17 @@
 # このファイルを .env にコピーして値を調整してください。
 
 # ストレージディレクトリのパス (未指定の場合はプロジェクト直下の .storage を使用)
-#SIMPLEBBS_STORAGE_PATH=/absolute/path/to/storage
+# 互換性のため SIMPLEBBS_STORAGE_PATH も利用できます
+#STORAGE_PATH=/absolute/path/to/storage
 
 # ログインを必須にするかどうか (true/false)
+# 互換性のため SIMPLEBBS_REQUIRE_LOGIN も利用できます
 MUST_LOGIN=false
 
 # 匿名投稿を許可するかどうか (true/false)
+# 互換性のため SIMPLEBBS_ALLOW_ANONYMOUS_POST も利用できます
 ANONYMOUS_POST=true
 
 # ユーザーによるボード作成を許可するかどうか (true/false)
-USER_BOARD_CREAT=true
+# 互換性のため SIMPLEBBS_ALLOW_USER_BOARD_CREATION も利用できます
+USER_BOARD_CREATE=true

--- a/src/Controllers/BoardController.php
+++ b/src/Controllers/BoardController.php
@@ -41,6 +41,16 @@ class BoardController
             return;
         }
 
+        if (!$request->user()) {
+            http_response_code(403);
+            $boards = $this->boardManager->listBoards();
+            echo $this->view->render('boards/index.twig', [
+                'boards' => $boards,
+                'errors' => ['ボードを作成するにはログインが必要です。'],
+            ]);
+            return;
+        }
+
         try {
             $board = $this->boardManager->createBoard(
                 (string)$request->input('title'),

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -31,22 +31,22 @@ class Config
     {
         $settings = [];
 
-        $requireLogin = getenv('SIMPLEBBS_REQUIRE_LOGIN');
+        $requireLogin = self::getEnvValue(['MUST_LOGIN', 'SIMPLEBBS_REQUIRE_LOGIN']);
         if ($requireLogin !== false) {
             $settings['require_login'] = self::toBool($requireLogin);
         }
 
-        $allowAnonymous = getenv('SIMPLEBBS_ALLOW_ANONYMOUS_POST');
+        $allowAnonymous = self::getEnvValue(['ANONYMOUS_POST', 'SIMPLEBBS_ALLOW_ANONYMOUS_POST']);
         if ($allowAnonymous !== false) {
             $settings['allow_anonymous_posting'] = self::toBool($allowAnonymous);
         }
 
-        $allowBoardCreation = getenv('SIMPLEBBS_ALLOW_USER_BOARD_CREATION');
+        $allowBoardCreation = self::getEnvValue(['USER_BOARD_CREATE', 'SIMPLEBBS_ALLOW_USER_BOARD_CREATION']);
         if ($allowBoardCreation !== false) {
             $settings['allow_user_board_creation'] = self::toBool($allowBoardCreation);
         }
 
-        $storagePath = getenv('SIMPLEBBS_STORAGE_PATH');
+        $storagePath = self::getEnvValue(['STORAGE_PATH', 'SIMPLEBBS_STORAGE_PATH']);
         if ($storagePath !== false) {
             $settings['storage_path'] = $storagePath;
         }
@@ -137,5 +137,20 @@ class Config
             $_ENV[$key] = $value;
             $_SERVER[$key] = $value;
         }
+    }
+
+    /**
+     * @param string[] $keys
+     */
+    private static function getEnvValue(array $keys): string|false
+    {
+        foreach ($keys as $key) {
+            $value = getenv($key);
+            if ($value !== false) {
+                return $value;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## 概要
- 環境変数の短縮名を読み込めるようにし、サンプル設定とドキュメントを更新
- ボード作成フォームをログイン済みユーザーのみに表示し、未ログイン時は案内を表示
- ボード作成処理でも未ログインを拒否して、ログイン前提での作成制御を実装

## テスト
- `php -l src/Support/Config.php`
- `php -l src/Controllers/BoardController.php`


------
https://chatgpt.com/codex/tasks/task_e_68dce04c6728833083db810f5db6d566