### PR TITLE
環境変数名の整理とボード作成設定の明確化

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ composer require simplebbs/simple-bbs
   - `true` の場合はログイン必須となり、認証の設定がないとアプリケーションが起動しません。
 - `SIMPLEBBS_ALLOW_ANONYMOUS_POST` (既定値: `true`)
   - 匿名でのスレッド作成・投稿を許可します。`false` にすると未ログイン時は投稿できません。
-- `SIMPLEBBS_ALLOW_USER_BOARD_CREATION` (既定値: `true`)
-  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。設定値に関わらず、ボード作成を行うにはログインが必要です。
+- `SIMPLEBBS_ALLOW_BOARD_CREATE` (既定値: `true`)
+  - ログイン済みユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。互換性のため、`SIMPLEBBS_ALLOW_USER_BOARD_CREATION` も引き続き読み込まれます。
 
 ### 認証設定
 

--- a/sample.env
+++ b/sample.env
@@ -10,6 +10,6 @@ SIMPLEBBS_REQUIRE_LOGIN=false
 # 匿名投稿を許可するかどうか (true/false)
 SIMPLEBBS_ALLOW_ANONYMOUS_POST=true
 
-# ユーザーによるボード作成を許可するかどうか (true/false)
-# ボード作成はログイン済みのユーザーのみが実行できます。
-SIMPLEBBS_ALLOW_USER_BOARD_CREATION=true
+# ログイン済みユーザーによるボード作成を許可するかどうか (true/false)
+# ボード作成はログインが前提となります。
+SIMPLEBBS_ALLOW_BOARD_CREATE=true

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -41,7 +41,11 @@ class Config
             $settings['allow_anonymous_posting'] = self::toBool($allowAnonymous);
         }
 
-        $allowBoardCreation = getenv('SIMPLEBBS_ALLOW_USER_BOARD_CREATION');
+        $allowBoardCreation = getenv('SIMPLEBBS_ALLOW_BOARD_CREATE');
+        if ($allowBoardCreation === false) {
+            $allowBoardCreation = getenv('SIMPLEBBS_ALLOW_USER_BOARD_CREATION');
+        }
+
         if ($allowBoardCreation !== false) {
             $settings['allow_user_board_creation'] = self::toBool($allowBoardCreation);
         }


### PR DESCRIPTION
## 概要
- ボード作成許可の環境変数名を短縮し、サンプル環境変数ファイルの説明を更新
- 環境変数読込処理で従来の変数名も後方互換として受け付けるよう調整
- ドキュメントに新しい環境変数名とログイン前提の説明を追記

## テスト
- 実施していません

------
https://chatgpt.com/codex/tasks/task_e_68dce2ae293c8330bddfea52952376e3