### PR TITLE
環境変数名の簡素化とボード作成条件の整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ composer require simplebbs/simple-bbs
 
 ## セットアップ
 1. Web ルートを `vendor/simplebbs/simple-bbs/public` に向けるか、`public/` ディレクトリの内容を任意の公開ディレクトリに配置します。
-2. `.storage/` ディレクトリを BBS のデータ格納用に書き込み可能へ設定するか、`.env` (または環境変数 `SIMPLEBBS_STORAGE_PATH`) で任意の書き込み先パスを指定します。設定例は `sample.env` を参照してください。
+2. `.storage/` ディレクトリを BBS のデータ格納用に書き込み可能へ設定するか、`.env` (または環境変数 `STORAGE_PATH`) で任意の書き込み先パスを指定します。設定例は `sample.env` を参照してください。
 3. ブラウザでアクセスすると、ボード作成からスレッド・投稿まで利用できます。
 
 `public/index.php` では `SimpleBBS\\Application` を生成し、HTTP リクエストを処理します。設置先で Twig のカスタマイズを行いたい場合は、
@@ -21,12 +21,16 @@ composer require simplebbs/simple-bbs
 
 `.env` または環境変数で以下の項目を設定できます。未指定の場合は既定値が使用されます。
 
-- `SIMPLEBBS_REQUIRE_LOGIN` (既定値: `false`)
+- `LOGIN_REQUIRED` (既定値: `false`)
   - `true` の場合はログイン必須となり、認証の設定がないとアプリケーションが起動しません。
-- `SIMPLEBBS_ALLOW_ANONYMOUS_POST` (既定値: `true`)
+- `ALLOW_GUEST_POSTS` (既定値: `true`)
   - 匿名でのスレッド作成・投稿を許可します。`false` にすると未ログイン時は投稿できません。
-- `SIMPLEBBS_ALLOW_USER_BOARD_CREATION` (既定値: `true`)
-  - ユーザーによる新規ボード作成を許可します。`false` にすると作成フォームが表示されません。設定値に関わらず、ボード作成を行うにはログインが必要です。
+- `ALLOW_BOARD_CREATION` (既定値: `false`)
+  - ログイン済みユーザーによる新規ボード作成を許可します。ログインを無効にしている場合は自動的にボード作成も無効になります。
+- `STORAGE_PATH` (既定値: プロジェクト直下の `.storage` ディレクトリ)
+  - BBS のデータを保存するディレクトリパスを指定します。
+
+互換性のため、旧名称の `SIMPLEBBS_REQUIRE_LOGIN`、`SIMPLEBBS_ALLOW_ANONYMOUS_POST`、`SIMPLEBBS_ALLOW_USER_BOARD_CREATION`、`SIMPLEBBS_STORAGE_PATH` も読み込まれます。
 
 ### 認証設定
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ docs/                   ... ドキュメント
 
 ## 組み込み手順概要
 1. `composer require simplebbs/simple-bbs` でパッケージを導入。(開発中はローカルパス指定も可能)
-2. `public/index.php` を Web ルートに配置し、`.storage/` ディレクトリへの書き込み権限を付与するか、環境変数 `SIMPLEBBS_STORAGE_PATH`
+2. `public/index.php` を Web ルートに配置し、`.storage/` ディレクトリへの書き込み権限を付与するか、環境変数 `STORAGE_PATH`
    で別のディレクトリを指定します。
 3. 必要に応じて Twig テンプレートや CSS をカスタマイズしてサイトデザインと統一。
 

--- a/sample.env
+++ b/sample.env
@@ -2,14 +2,14 @@
 # このファイルを .env にコピーして値を調整してください。
 
 # ストレージディレクトリのパス (未指定の場合はプロジェクト直下の .storage を使用)
-#SIMPLEBBS_STORAGE_PATH=/absolute/path/to/storage
+#STORAGE_PATH=/absolute/path/to/storage
 
 # ログインを必須にするかどうか (true/false)
-SIMPLEBBS_REQUIRE_LOGIN=false
+LOGIN_REQUIRED=false
 
 # 匿名投稿を許可するかどうか (true/false)
-SIMPLEBBS_ALLOW_ANONYMOUS_POST=true
+ALLOW_GUEST_POSTS=true
 
 # ユーザーによるボード作成を許可するかどうか (true/false)
-# ボード作成はログイン済みのユーザーのみが実行できます。
-SIMPLEBBS_ALLOW_USER_BOARD_CREATION=true
+# ログインを無効にしている場合はボード作成も自動的に無効になります。
+ALLOW_BOARD_CREATION=false


### PR DESCRIPTION
## 概要
- sample.env とドキュメントの環境変数名を短く分かりやすい名称に刷新し、旧名称との互換性を明記
- Config 読み込み処理を新名称へ対応させつつ旧名称をフォールバックする仕組みを追加
- ログインを無効にした場合はユーザーによるボード作成を自動的に無効化するよう調整

## 動作確認
- `php -l src/Support/Config.php`


------
https://chatgpt.com/codex/tasks/task_e_68dce380ce0c83309dfbb54d7050568f