### PR TITLE
BoardController読み込みエラーを解消

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -15,9 +15,7 @@ use SimpleBBS\Support\Config;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
-if (!class_exists(SimpleBBS::class, false)) {
-    require_once __DIR__ . '/autoload.php';
-}
+require_once __DIR__ . '/autoload.php';
 
 class Application
 {


### PR DESCRIPTION
## 概要
- Applicationの初期化時に常に独自オートローダーを登録するよう修正

## 動作確認
- php -l src/Application.php

------
https://chatgpt.com/codex/tasks/task_e_68dce6ba4be083309e23fded2a89d526