### PR TITLE
メールアドレス認証フローを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ composer require simplebbs/simple-bbs
 
 ### 認証設定
 
-ログインを利用する場合は Google OAuth クライアントを用意し、以下の環境変数を設定してください。
+simpleBBS にはメールアドレスとパスワードによるログイン機能が標準で組み込まれています。ログインページからメールアドレスを登録すると、パスワード設定用のURLを `.storage/mail.log` に書き出します。本番環境ではこのファイルをトリガーにして実際のメール送信処理へ接続してください。
+
+Google OAuth を併用する場合は以下の環境変数を設定します。
 
 - `SIMPLEBBS_GOOGLE_CLIENT_ID`
 - `SIMPLEBBS_GOOGLE_CLIENT_SECRET`
 - `SIMPLEBBS_GOOGLE_REDIRECT_URI` (例: `https://example.com/index.php?route=auth.callback`)
 
 他システムに組み込んで利用する場合は、`SimpleBBS\Auth\PreAuthenticatedAuthenticator` を利用して認証済みユーザー情報を渡してください。
-
-ログインを必須にしない場合は上記の環境変数を設定しなくても動作します。
 
 ```php
 use SimpleBBS\Auth\PreAuthenticatedAuthenticator;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,8 @@ docs/                   ... ドキュメント
 ## データベース
 - **システムDB (`.storage/system.sqlite`)**
   - `boards` テーブル: ボードのメタ情報(スラッグ、タイトル、説明、作成日時) を保持。
+  - `users` テーブル: ログインユーザーの氏名・メールアドレス・パスワードハッシュを保持。
+  - `password_resets` テーブル: パスワード設定用トークンと有効期限を保持。
 - **ボードDB (`.storage/boards/{slug}.sqlite`)**
   - `threads` テーブル: スレッドタイトルと作成・更新日時。
   - `posts` テーブル: スレッド内の投稿(投稿者、本文、投稿日時)。
@@ -48,7 +50,8 @@ docs/                   ... ドキュメント
 
 ## 認証
 - `Auth\AuthManager` がリクエストごとの認証状態を判定し、Twig へログイン中のユーザー情報を共有します。
-- スタンドアロン利用時は `Auth\GoogleAuthenticator` が Google OAuth 2.0 を利用してセッションにユーザー情報を保存します。
+- スタンドアロン利用時は `Auth\HybridAuthenticator` が `Auth\SessionAuthenticator` と `Auth\GoogleAuthenticator` を組み合わせ、メールアドレス/パスワードまたは Google OAuth のどちらでもログインできるようにしています。
+- `Services\PasswordAuthService` がメールアドレス登録・パスワード設定リンク生成・パスワード更新を担当し、`Support\PasswordSetupMailer` がリンクを `.storage/mail.log` に書き出します。
 - 他システム組み込み時は `Auth\PreAuthenticatedAuthenticator` により外部で認証済みの `Auth\User` を注入できます。
 
 ## ルーティング

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -116,6 +116,12 @@ a:hover {
     margin-bottom: 1rem;
 }
 
+.c-alert--success {
+    border-color: #34d399;
+    background: #d1fae5;
+    color: #047857;
+}
+
 .c-alert ul {
     margin: 0;
     padding-left: 1.25rem;

--- a/resources/views/auth/login.twig
+++ b/resources/views/auth/login.twig
@@ -15,13 +15,36 @@
         </div>
     {% endif %}
 
+    {% if notice == 'registration_sent' %}
+        <div class="c-alert c-alert--success">
+            <p>{{ values.email }} 宛にパスワード設定用のメールを送信しました。メール内のリンクからパスワードを設定してください。</p>
+        </div>
+    {% endif %}
+
     {% if login.message is defined %}
         <p>{{ login.message }}</p>
     {% endif %}
 
-    {% if login.loginRoute is defined %}
-        <p>Googleアカウントでログインしてください。</p>
-        <a href="{{ login.loginRoute }}" class="c-button">Googleでログイン</a>
+    {% if supportsPassword %}
+        <form method="post" action="{{ login.password.action }}" class="c-form">
+            <div class="c-form__row">
+                <label for="email">メールアドレス</label>
+                <input type="email" name="email" id="email" value="{{ values.email }}" required>
+            </div>
+            <div class="c-form__row">
+                <label for="password">パスワード</label>
+                <input type="password" name="password" id="password" required>
+            </div>
+            <div class="c-form__actions">
+                <button type="submit" class="c-button">ログイン</button>
+            </div>
+        </form>
+        <p><a href="{{ login.password.registerRoute }}" class="c-button c-button--link">新規登録はこちら</a></p>
+    {% endif %}
+
+    {% if login.google is defined %}
+        <p>Googleアカウントでログインすることもできます。</p>
+        <a href="{{ login.google.loginRoute }}" class="c-button">Googleでログイン</a>
     {% endif %}
 </section>
 {% endblock %}

--- a/resources/views/auth/password_invalid.twig
+++ b/resources/views/auth/password_invalid.twig
@@ -1,0 +1,11 @@
+{% extends 'base.twig' %}
+
+{% block title %}リンクが無効です | simpleBBS{% endblock %}
+
+{% block content %}
+<section class="c-panel">
+    <h2 class="c-panel__title">リンクが無効です</h2>
+    <p>パスワード設定用のリンクが無効、または有効期限が切れている可能性があります。お手数ですが、再度登録を行ってください。</p>
+    <p><a href="?route=auth.register" class="c-button c-button--link">ユーザー登録に戻る</a></p>
+</section>
+{% endblock %}

--- a/resources/views/auth/password_set.twig
+++ b/resources/views/auth/password_set.twig
@@ -1,0 +1,36 @@
+{% extends 'base.twig' %}
+
+{% block title %}パスワード設定 | simpleBBS{% endblock %}
+
+{% block content %}
+<section class="c-panel">
+    <h2 class="c-panel__title">パスワードを設定してください</h2>
+    <p>{{ user.email }} 宛に送信されたリンクからアクセスしています。新しいパスワードを入力してください。</p>
+
+    {% if errors is not empty %}
+        <div class="c-alert">
+            <ul>
+                {% for error in errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    <form method="post" action="?route=auth.password.update" class="c-form">
+        <input type="hidden" name="token" value="{{ token }}">
+        <div class="c-form__row c-form__row--static">対象ユーザー: <strong>{{ user.name ?: user.email }}</strong></div>
+        <div class="c-form__row">
+            <label for="password">新しいパスワード</label>
+            <input type="password" name="password" id="password" required minlength="8">
+        </div>
+        <div class="c-form__row">
+            <label for="password_confirmation">新しいパスワード（確認）</label>
+            <input type="password" name="password_confirmation" id="password_confirmation" required minlength="8">
+        </div>
+        <div class="c-form__actions">
+            <button type="submit" class="c-button">パスワードを設定する</button>
+        </div>
+    </form>
+</section>
+{% endblock %}

--- a/resources/views/auth/register.twig
+++ b/resources/views/auth/register.twig
@@ -1,0 +1,34 @@
+{% extends 'base.twig' %}
+
+{% block title %}ユーザー登録 | simpleBBS{% endblock %}
+
+{% block content %}
+<section class="c-panel">
+    <h2 class="c-panel__title">ユーザー登録</h2>
+    <p>メールアドレスを登録すると、パスワード設定用のURLをメールでお送りします。</p>
+
+    {% if errors is not empty %}
+        <div class="c-alert">
+            <ul>
+                {% for error in errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+
+    <form method="post" action="?route=auth.register" class="c-form">
+        <div class="c-form__row">
+            <label for="name">お名前</label>
+            <input type="text" name="name" id="name" value="{{ values.name }}" required>
+        </div>
+        <div class="c-form__row">
+            <label for="email">メールアドレス</label>
+            <input type="email" name="email" id="email" value="{{ values.email }}" required>
+        </div>
+        <div class="c-form__actions">
+            <button type="submit" class="c-button">登録してメールを受け取る</button>
+        </div>
+    </form>
+</section>
+{% endblock %}

--- a/src/Auth/AuthManager.php
+++ b/src/Auth/AuthManager.php
@@ -25,6 +25,16 @@ class AuthManager
         return $this->authenticator->supportsLoginRedirect();
     }
 
+    public function supportsPasswordLogin(): bool
+    {
+        return $this->authenticator->supportsPasswordLogin();
+    }
+
+    public function supportsLogin(): bool
+    {
+        return $this->supportsLoginRedirect() || $this->supportsPasswordLogin();
+    }
+
     public function initiateLogin(Request $request): void
     {
         $this->authenticator->initiateLogin($request);

--- a/src/Auth/AuthenticatorInterface.php
+++ b/src/Auth/AuthenticatorInterface.php
@@ -10,6 +10,8 @@ interface AuthenticatorInterface
 
     public function supportsLoginRedirect(): bool;
 
+    public function supportsPasswordLogin(): bool;
+
     public function initiateLogin(Request $request): void;
 
     public function handleCallback(Request $request): ?User;

--- a/src/Auth/GoogleAuthenticator.php
+++ b/src/Auth/GoogleAuthenticator.php
@@ -41,6 +41,11 @@ class GoogleAuthenticator implements AuthenticatorInterface
         return true;
     }
 
+    public function supportsPasswordLogin(): bool
+    {
+        return false;
+    }
+
     public function initiateLogin(Request $request): void
     {
         $this->ensureSession();

--- a/src/Auth/GuestAuthenticator.php
+++ b/src/Auth/GuestAuthenticator.php
@@ -16,6 +16,11 @@ class GuestAuthenticator implements AuthenticatorInterface
         return false;
     }
 
+    public function supportsPasswordLogin(): bool
+    {
+        return false;
+    }
+
     public function initiateLogin(Request $request): void
     {
         // ゲストモードでは何もしません。

--- a/src/Auth/HybridAuthenticator.php
+++ b/src/Auth/HybridAuthenticator.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace SimpleBBS\Auth;
+
+use SimpleBBS\Http\Request;
+
+class HybridAuthenticator implements AuthenticatorInterface
+{
+    public function __construct(
+        private readonly SessionAuthenticator $sessionAuthenticator,
+        private readonly ?AuthenticatorInterface $secondary = null
+    ) {
+    }
+
+    public function currentUser(Request $request): ?User
+    {
+        $user = $this->sessionAuthenticator->currentUser($request);
+
+        if ($user) {
+            return $user;
+        }
+
+        if ($this->secondary) {
+            return $this->secondary->currentUser($request);
+        }
+
+        return null;
+    }
+
+    public function supportsLoginRedirect(): bool
+    {
+        return $this->secondary?->supportsLoginRedirect() ?? false;
+    }
+
+    public function supportsPasswordLogin(): bool
+    {
+        return $this->sessionAuthenticator->supportsPasswordLogin();
+    }
+
+    public function initiateLogin(Request $request): void
+    {
+        if ($this->secondary && $this->secondary->supportsLoginRedirect()) {
+            $this->secondary->initiateLogin($request);
+
+            return;
+        }
+
+        $this->sessionAuthenticator->initiateLogin($request);
+    }
+
+    public function handleCallback(Request $request): ?User
+    {
+        if ($this->secondary) {
+            $user = $this->secondary->handleCallback($request);
+
+            if ($user) {
+                return $user;
+            }
+        }
+
+        return $this->sessionAuthenticator->handleCallback($request);
+    }
+
+    public function logout(Request $request): void
+    {
+        $this->sessionAuthenticator->logout($request);
+
+        if ($this->secondary) {
+            $this->secondary->logout($request);
+        }
+    }
+
+    public function loginViewData(): array
+    {
+        $data = $this->sessionAuthenticator->loginViewData();
+
+        if ($this->secondary) {
+            $data['google'] = $this->secondary->loginViewData();
+        }
+
+        return $data;
+    }
+
+    public function session(): SessionAuthenticator
+    {
+        return $this->sessionAuthenticator;
+    }
+}

--- a/src/Auth/PreAuthenticatedAuthenticator.php
+++ b/src/Auth/PreAuthenticatedAuthenticator.php
@@ -20,6 +20,11 @@ class PreAuthenticatedAuthenticator implements AuthenticatorInterface
         return false;
     }
 
+    public function supportsPasswordLogin(): bool
+    {
+        return false;
+    }
+
     public function initiateLogin(Request $request): void
     {
         // 組み込み利用時は外部システムで認証済みの想定のため特別な処理は不要

--- a/src/Auth/SessionAuthenticator.php
+++ b/src/Auth/SessionAuthenticator.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SimpleBBS\Auth;
+
+use SimpleBBS\Http\Request;
+use SimpleBBS\Repositories\UserRepository;
+
+class SessionAuthenticator implements AuthenticatorInterface
+{
+    public function __construct(private readonly UserRepository $users)
+    {
+    }
+
+    public function currentUser(Request $request): ?User
+    {
+        $this->ensureSession();
+
+        $userId = $_SESSION['simplebbs_user_id'] ?? null;
+
+        if (!$userId) {
+            return null;
+        }
+
+        $record = $this->users->findById((int)$userId);
+
+        if (!$record) {
+            unset($_SESSION['simplebbs_user_id']);
+
+            return null;
+        }
+
+        return new User(
+            (string)$record['id'],
+            (string)$record['name'],
+            (string)$record['email']
+        );
+    }
+
+    public function supportsLoginRedirect(): bool
+    {
+        return false;
+    }
+
+    public function supportsPasswordLogin(): bool
+    {
+        return true;
+    }
+
+    public function initiateLogin(Request $request): void
+    {
+        // フォームによるログインのため、ここで行う処理はありません。
+    }
+
+    public function handleCallback(Request $request): ?User
+    {
+        return $this->currentUser($request);
+    }
+
+    public function logout(Request $request): void
+    {
+        $this->ensureSession();
+
+        unset($_SESSION['simplebbs_user_id']);
+    }
+
+    public function loginViewData(): array
+    {
+        return [
+            'password' => [
+                'enabled' => true,
+                'action' => '?route=auth.login.attempt',
+                'registerRoute' => '?route=auth.register',
+            ],
+        ];
+    }
+
+    public function loginUserId(int $userId): void
+    {
+        $this->ensureSession();
+
+        $_SESSION['simplebbs_user_id'] = $userId;
+    }
+
+    private function ensureSession(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+    }
+}

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -4,13 +4,15 @@ namespace SimpleBBS\Controllers;
 
 use SimpleBBS\Auth\AuthManager;
 use SimpleBBS\Http\Request;
+use SimpleBBS\Services\PasswordAuthService;
 use Twig\Environment;
 
 class AuthController
 {
     public function __construct(
         private readonly Environment $view,
-        private readonly AuthManager $authManager
+        private readonly AuthManager $authManager,
+        private readonly ?PasswordAuthService $passwordAuth = null
     ) {
     }
 
@@ -24,6 +26,38 @@ class AuthController
         return $this->view->render('auth/login.twig', [
             'errors' => [],
             'login' => $this->authManager->loginViewData(),
+            'supportsPassword' => $this->authManager->supportsPasswordLogin(),
+            'notice' => (string)$request->query('notice', ''),
+            'values' => ['email' => (string)$request->query('email', '')],
+        ]);
+    }
+
+    public function attemptLogin(Request $request): string
+    {
+        if (!$this->passwordAuth || !$this->authManager->supportsPasswordLogin()) {
+            header('Location: ?route=auth.login');
+            exit;
+        }
+
+        $email = (string)$request->input('email', '');
+        $password = (string)$request->input('password', '');
+        $errors = [];
+
+        if (!$this->passwordAuth->attemptLogin($email, $password)) {
+            $errors[] = 'メールアドレスまたはパスワードが正しくありません。';
+        }
+
+        if ($errors === []) {
+            header('Location: ?route=boards.index');
+            exit;
+        }
+
+        return $this->view->render('auth/login.twig', [
+            'errors' => $errors,
+            'login' => $this->authManager->loginViewData(),
+            'supportsPassword' => $this->authManager->supportsPasswordLogin(),
+            'notice' => '',
+            'values' => ['email' => $email],
         ]);
     }
 
@@ -55,8 +89,145 @@ class AuthController
     public function logout(Request $request): void
     {
         $this->authManager->logout($request);
-        $target = $this->authManager->supportsLoginRedirect() ? '?route=auth.login' : '?route=boards.index';
+        $target = $this->authManager->supportsLogin() ? '?route=auth.login' : '?route=boards.index';
         header('Location: ' . $target);
         exit;
+    }
+
+    public function showRegister(Request $request): string
+    {
+        if (!$this->passwordAuth || !$this->authManager->supportsPasswordLogin()) {
+            header('Location: ?route=auth.login');
+            exit;
+        }
+
+        return $this->view->render('auth/register.twig', [
+            'errors' => [],
+            'values' => [
+                'name' => (string)$request->query('name', ''),
+                'email' => (string)$request->query('email', ''),
+            ],
+        ]);
+    }
+
+    public function register(Request $request): string
+    {
+        if (!$this->passwordAuth || !$this->authManager->supportsPasswordLogin()) {
+            header('Location: ?route=auth.login');
+            exit;
+        }
+
+        $name = trim((string)$request->input('name', ''));
+        $email = trim((string)$request->input('email', ''));
+        $errors = [];
+
+        if ($name === '') {
+            $errors[] = 'お名前を入力してください。';
+        }
+
+        if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $errors[] = '有効なメールアドレスを入力してください。';
+        }
+
+        if ($errors !== []) {
+            return $this->view->render('auth/register.twig', [
+                'errors' => $errors,
+                'values' => [
+                    'name' => $name,
+                    'email' => $email,
+                ],
+            ]);
+        }
+
+        $this->passwordAuth->requestPasswordSetup(
+            $name,
+            $email,
+            fn (string $token): string => $this->buildAbsoluteUrl('auth.password.edit', ['token' => $token])
+        );
+
+        header('Location: ?route=auth.login&notice=registration_sent&email=' . rawurlencode($email));
+        exit;
+    }
+
+    public function showPasswordForm(Request $request): string
+    {
+        if (!$this->passwordAuth || !$this->authManager->supportsPasswordLogin()) {
+            header('Location: ?route=auth.login');
+            exit;
+        }
+
+        $token = (string)$request->query('token', '');
+        $data = $this->passwordAuth->findPasswordToken($token);
+
+        if (!$data) {
+            return $this->view->render('auth/password_invalid.twig');
+        }
+
+        return $this->view->render('auth/password_set.twig', [
+            'errors' => [],
+            'token' => $data['token'],
+            'user' => $data['user'],
+        ]);
+    }
+
+    public function updatePassword(Request $request): string
+    {
+        if (!$this->passwordAuth || !$this->authManager->supportsPasswordLogin()) {
+            header('Location: ?route=auth.login');
+            exit;
+        }
+
+        $token = (string)$request->input('token', '');
+        $password = (string)$request->input('password', '');
+        $confirmation = (string)$request->input('password_confirmation', '');
+        $errors = [];
+        $data = $this->passwordAuth->findPasswordToken($token);
+
+        if (!$data) {
+            return $this->view->render('auth/password_invalid.twig');
+        }
+
+        if (mb_strlen($password) < 8) {
+            $errors[] = 'パスワードは8文字以上で入力してください。';
+        }
+
+        if ($password !== $confirmation) {
+            $errors[] = '確認用パスワードが一致しません。';
+        }
+
+        if ($errors !== []) {
+            return $this->view->render('auth/password_set.twig', [
+                'errors' => $errors,
+                'token' => $data['token'],
+                'user' => $data['user'],
+            ]);
+        }
+
+        if ($this->passwordAuth->completePasswordSetup($token, $password)) {
+            header('Location: ?route=boards.index');
+            exit;
+        }
+
+        return $this->view->render('auth/password_invalid.twig');
+    }
+
+    /**
+     * @param array<string, string> $parameters
+     */
+    private function buildAbsoluteUrl(string $route, array $parameters = []): string
+    {
+        $host = $_SERVER['HTTP_HOST'] ?? null;
+        $script = $_SERVER['SCRIPT_NAME'] ?? '';
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+
+        if ($host) {
+            $base = sprintf('%s://%s%s', $scheme, $host, $script);
+        } else {
+            $base = $script;
+        }
+
+        $params = array_merge(['route' => $route], $parameters);
+
+        return $base . (str_contains($base, '?') ? '&' : '?') . http_build_query($params);
     }
 }

--- a/src/Repositories/UserRepository.php
+++ b/src/Repositories/UserRepository.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace SimpleBBS\Repositories;
+
+use DateTimeImmutable;
+use PDO;
+use PDOException;
+use SimpleBBS\Support\DatabaseManager;
+
+class UserRepository
+{
+    public function __construct(private readonly DatabaseManager $database)
+    {
+    }
+
+    public function findById(int $id): ?array
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare('SELECT * FROM users WHERE id = :id LIMIT 1');
+        $statement->execute(['id' => $id]);
+        $result = $statement->fetch(PDO::FETCH_ASSOC);
+
+        return $result === false ? null : $result;
+    }
+
+    public function findByEmail(string $email): ?array
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare('SELECT * FROM users WHERE email = :email LIMIT 1');
+        $statement->execute(['email' => strtolower($email)]);
+        $result = $statement->fetch(PDO::FETCH_ASSOC);
+
+        return $result === false ? null : $result;
+    }
+
+    public function createUser(string $name, string $email): int
+    {
+        $pdo = $this->database->getSystemConnection();
+        $now = (new DateTimeImmutable())->format(DATE_ATOM);
+
+        try {
+            $statement = $pdo->prepare(
+                'INSERT INTO users (name, email, password_hash, created_at, updated_at) '
+                . 'VALUES (:name, :email, NULL, :created_at, :updated_at)'
+            );
+            $statement->execute([
+                'name' => $name,
+                'email' => strtolower($email),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            return (int)$pdo->lastInsertId();
+        } catch (PDOException $exception) {
+            if ($exception->getCode() === '23000') {
+                $existing = $this->findByEmail($email);
+                if ($existing) {
+                    return (int)$existing['id'];
+                }
+            }
+
+            throw $exception;
+        }
+    }
+
+    public function updateUserName(int $id, string $name): void
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare(
+            'UPDATE users SET name = :name, updated_at = :updated_at WHERE id = :id'
+        );
+        $statement->execute([
+            'id' => $id,
+            'name' => $name,
+            'updated_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+        ]);
+    }
+
+    public function updatePassword(int $id, string $hash): void
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare(
+            'UPDATE users SET password_hash = :hash, password_set_at = :password_set_at, updated_at = :updated_at '
+            . 'WHERE id = :id'
+        );
+        $now = (new DateTimeImmutable())->format(DATE_ATOM);
+        $statement->execute([
+            'id' => $id,
+            'hash' => $hash,
+            'password_set_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    public function deletePasswordResetsForUser(int $userId): void
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare('DELETE FROM password_resets WHERE user_id = :user_id');
+        $statement->execute(['user_id' => $userId]);
+    }
+
+    public function storePasswordResetToken(int $userId, string $token, string $expiresAt): void
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare(
+            'INSERT INTO password_resets (user_id, token, expires_at, created_at) '
+            . 'VALUES (:user_id, :token, :expires_at, :created_at)'
+        );
+        $statement->execute([
+            'user_id' => $userId,
+            'token' => $token,
+            'expires_at' => $expiresAt,
+            'created_at' => (new DateTimeImmutable())->format(DATE_ATOM),
+        ]);
+    }
+
+    public function findPasswordResetByToken(string $token): ?array
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare('SELECT * FROM password_resets WHERE token = :token LIMIT 1');
+        $statement->execute(['token' => $token]);
+        $result = $statement->fetch(PDO::FETCH_ASSOC);
+
+        return $result === false ? null : $result;
+    }
+
+    public function deletePasswordResetByToken(string $token): void
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare('DELETE FROM password_resets WHERE token = :token');
+        $statement->execute(['token' => $token]);
+    }
+
+    public function purgeExpiredPasswordResets(string $now): void
+    {
+        $pdo = $this->database->getSystemConnection();
+        $statement = $pdo->prepare('DELETE FROM password_resets WHERE expires_at <= :now');
+        $statement->execute(['now' => $now]);
+    }
+}

--- a/src/Services/PasswordAuthService.php
+++ b/src/Services/PasswordAuthService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace SimpleBBS\Services;
+
+use DateTimeImmutable;
+use SimpleBBS\Auth\SessionAuthenticator;
+use SimpleBBS\Repositories\UserRepository;
+use SimpleBBS\Support\PasswordSetupMailer;
+
+class PasswordAuthService
+{
+    public function __construct(
+        private readonly UserRepository $users,
+        private readonly SessionAuthenticator $session,
+        private readonly PasswordSetupMailer $mailer
+    ) {
+    }
+
+    public function attemptLogin(string $email, string $password): bool
+    {
+        $normalizedEmail = strtolower(trim($email));
+
+        if ($normalizedEmail === '') {
+            return false;
+        }
+
+        $user = $this->users->findByEmail($normalizedEmail);
+
+        if (!$user) {
+            return false;
+        }
+
+        $hash = $user['password_hash'] ?? null;
+
+        if (!$hash || !password_verify($password, (string)$hash)) {
+            return false;
+        }
+
+        $this->session->loginUserId((int)$user['id']);
+
+        return true;
+    }
+
+    /**
+     * @param callable(string):string $urlGenerator
+     */
+    public function requestPasswordSetup(string $name, string $email, callable $urlGenerator): void
+    {
+        $normalizedEmail = strtolower(trim($email));
+        $name = trim($name);
+
+        $user = $this->users->findByEmail($normalizedEmail);
+
+        if (!$user) {
+            $userId = $this->users->createUser($name, $normalizedEmail);
+            $user = $this->users->findById($userId);
+        } elseif ($name !== '' && $name !== $user['name']) {
+            $this->users->updateUserName((int)$user['id'], $name);
+            $user = $this->users->findById((int)$user['id']);
+        }
+
+        if (!$user) {
+            return;
+        }
+
+        $this->users->deletePasswordResetsForUser((int)$user['id']);
+
+        $token = bin2hex(random_bytes(32));
+        $expiresAt = (new DateTimeImmutable('+1 day'))->format(DATE_ATOM);
+        $this->users->storePasswordResetToken((int)$user['id'], $token, $expiresAt);
+
+        $url = $urlGenerator($token);
+        $this->mailer->send($user['name'], $user['email'], $url);
+    }
+
+    public function findPasswordToken(string $token): ?array
+    {
+        $token = trim($token);
+
+        if ($token === '') {
+            return null;
+        }
+
+        $now = (new DateTimeImmutable())->format(DATE_ATOM);
+        $this->users->purgeExpiredPasswordResets($now);
+
+        $reset = $this->users->findPasswordResetByToken($token);
+
+        if (!$reset) {
+            return null;
+        }
+
+        $expiresAt = new DateTimeImmutable((string)$reset['expires_at']);
+
+        if ($expiresAt < new DateTimeImmutable()) {
+            $this->users->deletePasswordResetByToken($token);
+
+            return null;
+        }
+
+        $user = $this->users->findById((int)$reset['user_id']);
+
+        if (!$user) {
+            $this->users->deletePasswordResetByToken($token);
+
+            return null;
+        }
+
+        return [
+            'token' => $token,
+            'user' => $user,
+        ];
+    }
+
+    public function completePasswordSetup(string $token, string $password): bool
+    {
+        $data = $this->findPasswordToken($token);
+
+        if (!$data) {
+            return false;
+        }
+
+        $user = $data['user'];
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+
+        $this->users->updatePassword((int)$user['id'], $hash);
+        $this->users->deletePasswordResetsForUser((int)$user['id']);
+
+        $this->session->loginUserId((int)$user['id']);
+
+        return true;
+    }
+}

--- a/src/Support/DatabaseManager.php
+++ b/src/Support/DatabaseManager.php
@@ -89,6 +89,29 @@ class DatabaseManager
                 created_at TEXT NOT NULL
             )'
         );
+
+        $pdo->exec(
+            'CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                email TEXT NOT NULL UNIQUE,
+                password_hash TEXT DEFAULT NULL,
+                password_set_at TEXT DEFAULT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )'
+        );
+
+        $pdo->exec(
+            'CREATE TABLE IF NOT EXISTS password_resets (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                token TEXT NOT NULL UNIQUE,
+                expires_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
+            )'
+        );
     }
 
     private function initialiseBoardSchema(PDO $pdo): void

--- a/src/Support/PasswordSetupMailer.php
+++ b/src/Support/PasswordSetupMailer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SimpleBBS\Support;
+
+use DateTimeImmutable;
+
+class PasswordSetupMailer
+{
+    public function __construct(private readonly string $logFile)
+    {
+        $directory = dirname($this->logFile);
+
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+    }
+
+    public function send(string $name, string $email, string $url): void
+    {
+        $timestamp = (new DateTimeImmutable())->format('Y-m-d H:i:s');
+        $content = sprintf(
+            "[%s] %s <%s> 宛にパスワード設定リンクを送信しました:\n%s\n\n",
+            $timestamp,
+            $name === '' ? '(未設定)' : $name,
+            $email,
+            $url
+        );
+
+        file_put_contents($this->logFile, $content, FILE_APPEND);
+    }
+}


### PR DESCRIPTION
## 概要
- メールアドレス/パスワードのログイン機能を実装し、Googleログインとの併用を可能にしました。
- 登録用メール送信ログとユーザー・パスワードリセット用テーブルを追加しました。
- ログイン/登録ビューとドキュメントを更新しました。

## テスト
- php -l src/Application.php
- php -l src/Controllers/AuthController.php
- php -l src/Services/PasswordAuthService.php
- php -l src/Auth/SessionAuthenticator.php

------
https://chatgpt.com/codex/tasks/task_e_68dce89fe49c8330bd5aa1b864a5777e